### PR TITLE
Impact view; fixes #32

### DIFF
--- a/DEHCATIA.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHCATIA.Tests/DstController/DstControllerTestFixture.cs
@@ -315,16 +315,16 @@ namespace DEHCATIA.Tests.DstController
                 x =>
                     x.ShowDxDialog<CreateLogEntryDialog, CreateLogEntryDialogViewModel>(
                         It.IsAny<CreateLogEntryDialogViewModel>())
-                , Times.Exactly(1));
+                , Times.Exactly(4));
 
             this.hubController.Verify(
-                x => x.Write(It.IsAny<ThingTransaction>()), Times.Exactly(2));
+                x => x.Write(It.IsAny<ThingTransaction>()), Times.Exactly(4));
 
             this.hubController.Verify(
-                x => x.Refresh(), Times.Exactly(1));
+                x => x.Refresh(), Times.Exactly(2));
 
             this.exchangeHistory.Verify(x =>
-                x.Append(It.IsAny<Thing>(), It.IsAny<ChangeKind>()), Times.Exactly(4));
+                x.Append(It.IsAny<Thing>(), It.IsAny<ChangeKind>()), Times.Exactly(8));
         }
 
         [Test]
@@ -444,7 +444,7 @@ namespace DEHCATIA.Tests.DstController
 
             this.statusBar.Verify(
                 x => x.Append(It.IsAny<string>(), It.IsAny<StatusBarMessageSeverity>()),
-                Times.Exactly(17));
+                Times.Exactly(19));
         }
 
         [Test]
@@ -452,13 +452,13 @@ namespace DEHCATIA.Tests.DstController
         {
             this.elementRow.ElementDefinition = this.element;
             this.controller.ExternalIdentifierMap = new ExternalIdentifierMap();
-            Assert.DoesNotThrow(() => this.controller.SaveTheMapping(this.elementRow));
+            Assert.DoesNotThrow(() => this.controller.SaveElementMapping(this.elementRow));
             Assert.AreEqual(1, this.controller.ExternalIdentifierMap.Correspondence.Count);
             this.elementRow.SelectedOption = this.option;
-            Assert.DoesNotThrow(() => this.controller.SaveTheMapping(this.elementRow));
+            Assert.DoesNotThrow(() => this.controller.SaveElementMapping(this.elementRow));
             Assert.AreEqual(2, this.controller.ExternalIdentifierMap.Correspondence.Count);
             this.elementRow.SelectedActualFiniteState = this.state;
-            Assert.DoesNotThrow(() => this.controller.SaveTheMapping(this.elementRow));
+            Assert.DoesNotThrow(() => this.controller.SaveElementMapping(this.elementRow));
             Assert.AreEqual(3, this.controller.ExternalIdentifierMap.Correspondence.Count);
         }
     }

--- a/DEHCATIA.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHCATIA.Tests/DstController/DstControllerTestFixture.cs
@@ -51,6 +51,8 @@ namespace DEHCATIA.Tests.DstController
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
     using DEHPCommon.UserInterfaces.Views;
 
+    using DevExpress.Mvvm.Native;
+
     using Moq;
 
     using NUnit.Framework;
@@ -75,6 +77,9 @@ namespace DEHCATIA.Tests.DstController
         private Assembler assembler;
         private Mock<Product> product0;
         private Mock<Product> product1;
+        private Option option;
+        private ActualFiniteState state;
+        private ElementRowViewModel elementRow;
 
         [SetUp]
         public void Setup()
@@ -87,7 +92,7 @@ namespace DEHCATIA.Tests.DstController
             this.hubController = new Mock<IHubController>();
             this.navigationService = new Mock<INavigationService>();
 
-            this.element = new ElementDefinition();
+            this.element = new ElementDefinition(Guid.NewGuid(), null, null);
 
             var uri = new Uri("http://t.e");
 
@@ -114,8 +119,19 @@ namespace DEHCATIA.Tests.DstController
             this.hubController.Setup(x => x.OpenIteration).Returns(this.iteration);
 
             this.product0 = new Mock<Product>();
+            this.product0.Setup(x => x.get_DescriptionRef()).Returns(string.Empty);
+            this.product0.Setup(x => x.get_PartNumber()).Returns(string.Empty);
+            this.product0.Setup(x => x.get_Name()).Returns("product0");
             this.product1 = new Mock<Product>();
+            this.product1.Setup(x => x.get_DescriptionRef()).Returns(string.Empty);
+            this.product1.Setup(x => x.get_PartNumber()).Returns(string.Empty);
+            this.product1.Setup(x => x.get_Name()).Returns("product1");
 
+            this.elementRow = new ElementRowViewModel(this.product0.Object, string.Empty);
+
+            this.option = new Option(Guid.NewGuid(), null, null);
+            this.state = new ActualFiniteState(Guid.NewGuid(), null, null);
+            
             this.controller = new DstController(this.comService.Object, this.statusBar.Object, this.mappingEngine.Object,
                 this.exchangeHistory.Object, this.hubController.Object, this.navigationService.Object);
         }
@@ -141,10 +157,14 @@ namespace DEHCATIA.Tests.DstController
         [Test]
         public void VerifyGetProductTree()
         {
+            this.cancellationToken = new CancellationToken();
             Assert.IsFalse(this.controller.IsCatiaConnected);
             this.comService.Setup(x => x.GetProductTree(this.cancellationToken)).Returns(default(ElementRowViewModel));
-            Assert.IsNull(this.controller.GetProductTree(this.cancellationToken));
-            this.comService.Verify(x => x.GetProductTree(this.cancellationToken), Times.Once);
+            Assert.DoesNotThrow(() => this.controller.GetProductTree(this.cancellationToken));
+            this.cancellationToken = new CancellationToken();
+            Assert.DoesNotThrow(() => this.controller.GetProductTree(this.cancellationToken));
+            Assert.IsNull(this.controller.ProductTree);
+            this.comService.Verify(x => x.GetProductTree(this.cancellationToken), Times.Exactly(2));
         }
 
         [Test]
@@ -181,17 +201,17 @@ namespace DEHCATIA.Tests.DstController
                             (usageRowViewModel, new ElementUsage())
                         });
 
-            Assert.DoesNotThrow(() => this.controller.Map(new List<ElementRowViewModel>(){ rootElement }));
+            Assert.DoesNotThrow(() => this.controller.Map(rootElement));
 
             this.mappingEngine.Setup(x => x.Map(It.IsAny<object>()))
                 .Returns(new byte());
 
-            Assert.DoesNotThrow(() => this.controller.Map(new List<ElementRowViewModel>() { rootElement }));
+            Assert.DoesNotThrow(() => this.controller.Map(rootElement));
 
             this.mappingEngine.Setup(x => x.Map(It.IsAny<object>()))
                 .Returns(new List<(ElementRowViewModel, ElementBase)>());
 
-            Assert.DoesNotThrow(() => this.controller.Map(new List<ElementRowViewModel>() { rootElement }));
+            Assert.DoesNotThrow(() => this.controller.Map(rootElement));
                 
             this.mappingEngine.Verify(x => x.Map(It.IsAny<object>()), Times.Exactly(3));
         }
@@ -199,6 +219,8 @@ namespace DEHCATIA.Tests.DstController
         [Test]
         public void VerifyTransferToHub()
         {
+            this.controller.ExternalIdentifierMap = new ExternalIdentifierMap();
+            
             this.navigationService.Setup(
                 x => x.ShowDxDialog<CreateLogEntryDialog, CreateLogEntryDialogViewModel>(
                 It.IsAny<CreateLogEntryDialogViewModel>())).Returns(true);
@@ -259,6 +281,11 @@ namespace DEHCATIA.Tests.DstController
 
             this.hubController.Setup(x =>
                 x.GetThingById(parameterOverride.Iid, It.IsAny<Iteration>(), out parameterOverride));
+
+            var externalIdentifierMap = new ExternalIdentifierMap();
+
+            this.hubController.Setup(x =>
+                x.GetThingById(It.IsAny<Guid>(), It.IsAny<Iteration>(), out externalIdentifierMap));
 
             Assert.DoesNotThrowAsync(async () => await this.controller.TransferMappedThingsToHub());
 
@@ -349,6 +376,90 @@ namespace DEHCATIA.Tests.DstController
 
             this.hubController.Verify(x =>
                 x.Write(It.IsAny<ThingTransaction>()), Times.Once);
+        }
+
+        [Test]
+        public void VerifyCreateExternalIdentifierMap()
+        {
+            var newExternalIdentifierMap = this.controller.CreateExternalIdentifierMap("Name");
+            this.controller.ExternalIdentifierMap = newExternalIdentifierMap;
+            Assert.AreEqual("Name", this.controller.ExternalIdentifierMap.Name);
+            Assert.AreEqual("Name", this.controller.ExternalIdentifierMap.ExternalModelName);
+        }
+
+        [Test]
+        public void VerifyLoadMapping()
+        {
+            var parent = new ElementRowViewModel(this.product1.Object, string.Empty);
+
+            this.controller.ProductTree = parent;
+
+            Assert.DoesNotThrow(() => this.controller.LoadMapping());
+         
+            this.controller.ExternalIdentifierMap = new ExternalIdentifierMap()
+            {
+                Correspondence =
+                {
+                    new IdCorrespondence()
+                    {
+                        InternalThing = this.element.Iid,
+                        ExternalId = $"{MappingDirection.FromDstToHub}-{this.elementRow.Name}"
+                    },
+                    new IdCorrespondence()
+                    {
+                        InternalThing = this.option.Iid,
+                        ExternalId = $"{MappingDirection.FromDstToHub}-{this.elementRow.Name}"
+                    },
+                    new IdCorrespondence()
+                    {
+                        InternalThing = this.state.Iid,
+                        ExternalId = $"{MappingDirection.FromDstToHub}-{this.elementRow.Name}"
+                    }
+                }
+            };
+
+            Assert.DoesNotThrow(() => this.controller.LoadMapping());
+
+            this.controller.ExternalIdentifierMap.Iid = Guid.NewGuid();
+
+            Assert.DoesNotThrow(() => this.controller.LoadMapping());
+
+            this.hubController.Setup(x => x.GetThingById(this.element.Iid, It.IsAny<Iteration>(), out this.element)).Returns(false);
+            this.hubController.Setup(x => x.GetThingById(this.option.Iid, It.IsAny<Iteration>(), out this.option)).Returns(true);
+            this.hubController.Setup(x => x.GetThingById(this.state.Iid, It.IsAny<Iteration>(), out this.state)).Returns(true);
+
+            Assert.DoesNotThrow(() => this.controller.LoadMapping());
+
+            this.hubController.Setup(x => x.GetThingById(this.element.Iid, It.IsAny<Iteration>(), out this.element)).Returns(true);
+
+            Assert.DoesNotThrow(() => this.controller.LoadMapping());
+
+            this.controller.ProductTree.Children.Add(this.elementRow);
+
+            Assert.DoesNotThrow(() => this.controller.LoadMapping());
+
+            this.controller.ProductTree = this.elementRow;
+
+            Assert.DoesNotThrow(() => this.controller.LoadMapping());
+
+            this.statusBar.Verify(
+                x => x.Append(It.IsAny<string>(), It.IsAny<StatusBarMessageSeverity>()),
+                Times.Exactly(17));
+        }
+
+        [Test]
+        public void VerifySaveTheMapping()
+        {
+            this.elementRow.ElementDefinition = this.element;
+            this.controller.ExternalIdentifierMap = new ExternalIdentifierMap();
+            Assert.DoesNotThrow(() => this.controller.SaveTheMapping(this.elementRow));
+            Assert.AreEqual(1, this.controller.ExternalIdentifierMap.Correspondence.Count);
+            this.elementRow.SelectedOption = this.option;
+            Assert.DoesNotThrow(() => this.controller.SaveTheMapping(this.elementRow));
+            Assert.AreEqual(2, this.controller.ExternalIdentifierMap.Correspondence.Count);
+            this.elementRow.SelectedActualFiniteState = this.state;
+            Assert.DoesNotThrow(() => this.controller.SaveTheMapping(this.elementRow));
+            Assert.AreEqual(3, this.controller.ExternalIdentifierMap.Correspondence.Count);
         }
     }
 }

--- a/DEHCATIA.Tests/MappingRules/CatiaProductToElementRuleTestFixture.cs
+++ b/DEHCATIA.Tests/MappingRules/CatiaProductToElementRuleTestFixture.cs
@@ -112,7 +112,13 @@ namespace DEHCATIA.Tests.MappingRules
             AppContainer.Container = containerBuilder.Build();
 
             this.product0 = new Mock<Product>();
+            this.product0.Setup(x => x.get_DescriptionRef()).Returns(string.Empty);
+            this.product0.Setup(x => x.get_PartNumber()).Returns(string.Empty);
+            this.product0.Setup(x => x.get_Name()).Returns(string.Empty);
             this.product1 = new Mock<Product>();
+            this.product1.Setup(x => x.get_DescriptionRef()).Returns(string.Empty);
+            this.product1.Setup(x => x.get_PartNumber()).Returns(string.Empty);
+            this.product1.Setup(x => x.get_Name()).Returns(string.Empty);
 
             this.rule = new CatiaProductToElementRule();
         }
@@ -169,7 +175,7 @@ namespace DEHCATIA.Tests.MappingRules
             
             var result = new List<(ElementRowViewModel Parent, ElementBase Element)>();
 
-            Assert.DoesNotThrow(() => result = this.rule.Transform(new List<ElementRowViewModel>(){rootElement}));
+            Assert.DoesNotThrow(() => result = this.rule.Transform(rootElement));
             Assert.IsNotNull(result);
             Assert.AreEqual(3, result.Count);
         }

--- a/DEHCATIA.Tests/Services/ComConnector/CatiaComServiceTestFixture.cs
+++ b/DEHCATIA.Tests/Services/ComConnector/CatiaComServiceTestFixture.cs
@@ -38,7 +38,6 @@ namespace DEHCATIA.Tests.Services.ComConnector
     {
         private CatiaComService service;
         private Mock<IStatusBarControlViewModel> statusBar;
-        private CancellationToken cancellationToken;
 
         [SetUp]
         public void Setup()
@@ -58,7 +57,6 @@ namespace DEHCATIA.Tests.Services.ComConnector
         [Test]
         public void VerifyCatiaConnection()
         {
-            //this.service.CatiaApp = this.catiaApp.
             Assert.DoesNotThrow(() => this.service.Connect());
             Assert.IsTrue(this.service.IsCatiaConnected);
             Assert.IsNotNull(this.service.CatiaApp);
@@ -73,9 +71,8 @@ namespace DEHCATIA.Tests.Services.ComConnector
         [Test]
         public void VerifyGetProductTree()
         {
-            //this.service.CatiaApp = this.catiaApp.
             Assert.DoesNotThrow(() => this.service.Connect());
-            Assert.IsNotNull(this.service.GetProductTree(this.cancellationToken));
+            Assert.IsNotNull(this.service.GetProductTree(CancellationToken.None));
         }
     }
 }

--- a/DEHCATIA.Tests/ViewModels/CatiaTransferControlViewModel.cs
+++ b/DEHCATIA.Tests/ViewModels/CatiaTransferControlViewModel.cs
@@ -40,6 +40,7 @@ namespace DEHCATIA.Tests.ViewModels
     using DEHCATIA.DstController;
     using DEHCATIA.ViewModels;
     using DEHCATIA.ViewModels.ProductTree.Rows;
+    using DEHCATIA.ViewModels.Rows;
 
     using Moq;
 
@@ -69,7 +70,7 @@ namespace DEHCATIA.Tests.ViewModels
                 .Returns(new ReactiveList<(ElementRowViewModel, ElementBase)>());
 
             this.dstController.Setup(x => x.HubMapResult)
-                .Returns(new ReactiveList<ElementRowViewModel>());
+                .Returns(new ReactiveList<MappedElementDefinitionRowViewModel>());
 
             this.exchangeHistoryService = new Mock<IExchangeHistoryService>();
 
@@ -115,9 +116,9 @@ namespace DEHCATIA.Tests.ViewModels
                 (null, new ElementDefinition())
             });
 
-            this.dstController.Setup(x => x.HubMapResult).Returns(new ReactiveList<ElementRowViewModel>()
+            this.dstController.Setup(x => x.HubMapResult).Returns(new ReactiveList<MappedElementDefinitionRowViewModel>()
             {
-                new ElementRowViewModel(new Mock<Product>().Object, string.Empty)
+                new MappedElementDefinitionRowViewModel()
             });
 
             Assert.IsFalse(this.viewModel.CancelCommand.CanExecute(null));

--- a/DEHCATIA.Tests/ViewModels/CatiaTransferControlViewModel.cs
+++ b/DEHCATIA.Tests/ViewModels/CatiaTransferControlViewModel.cs
@@ -127,8 +127,8 @@ namespace DEHCATIA.Tests.ViewModels
             Assert.IsNotEmpty(this.dstController.Object.HubMapResult);
             Assert.IsNotEmpty(this.dstController.Object.DstMapResult);
             Assert.DoesNotThrow(() => this.viewModel.CancelCommand.ExecuteAsyncTask(null));
-            Assert.IsEmpty(this.dstController.Object.HubMapResult);
-            Assert.IsEmpty(this.dstController.Object.DstMapResult);
+            Assert.IsNotEmpty(this.dstController.Object.HubMapResult);
+            Assert.IsNotEmpty(this.dstController.Object.DstMapResult);
         }
     }
 }

--- a/DEHCATIA.Tests/ViewModels/Dialogs/DstLoginViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/Dialogs/DstLoginViewModelTestFixture.cs
@@ -1,0 +1,131 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DstLoginViewModelTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2020 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
+// 
+//    This file is part of DEHCATIA
+// 
+//    The DEHCATIA is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHCATIA is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.Tests.ViewModels.Dialogs
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reactive.Concurrency;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using CDP4Common.EngineeringModelData;
+
+    using DEHPCommon.Enumerators;
+    using DEHPCommon.HubController.Interfaces;
+    using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
+
+    using DEHCATIA.DstController;
+    using DEHCATIA.ViewModels.Dialogs;
+
+    using DEHPCommon.UserInterfaces.Behaviors;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using ReactiveUI;
+
+    [TestFixture]
+    public class DstLoginViewModelTestFixture
+    {
+        private Mock<IDstController> dstController;
+        private Mock<IHubController> hubController;
+        private Mock<IStatusBarControlViewModel> statusBar;
+        private DstLoginViewModel viewModel;
+        private Mock<ICloseWindowBehavior> closeWindowBehavior;
+
+        [SetUp]
+        public void Setup()
+        {
+            RxApp.MainThreadScheduler = Scheduler.CurrentThread;
+            this.dstController = new Mock<IDstController>();
+            this.dstController.Setup(x => x.IsCatiaConnected).Returns(true);
+
+            this.hubController = new Mock<IHubController>();
+
+            this.hubController.Setup(x => x.AvailableExternalIdentifierMap(It.IsAny<string>())).Returns(new List<ExternalIdentifierMap>()
+            {
+                new ExternalIdentifierMap(), new ExternalIdentifierMap(), new ExternalIdentifierMap()
+            });
+
+            this.statusBar = new Mock<IStatusBarControlViewModel>();
+            this.statusBar.Setup(x => x.Append(It.IsAny<string>(), It.IsAny<StatusBarMessageSeverity>()));
+
+            this.closeWindowBehavior = new Mock<ICloseWindowBehavior>();
+
+            this.viewModel = new DstLoginViewModel(this.dstController.Object, this.hubController.Object)
+            {
+                CloseWindowBehavior = this.closeWindowBehavior.Object
+            };
+        }
+
+        [Test]
+        public void VerifyProperties()
+        {
+            Assert.IsFalse(this.viewModel.LoginSuccessful);
+            Assert.IsNotNull(this.viewModel.CloseWindowBehavior);
+            
+            Assert.IsNotNull(this.viewModel.ConnectCommand);
+
+            Assert.IsFalse(this.viewModel.CreateNewMappingConfigurationChecked);
+            Assert.IsNull(this.viewModel.ExternalIdentifierMapNewName);
+            Assert.IsNull(this.viewModel.SelectedExternalIdentifierMap);
+            Assert.AreEqual(3, this.viewModel.AvailableExternalIdentifierMap.Count);
+        }
+
+        [Test]
+        public void VerifySpecifyExternalIdentifierMap()
+        {
+            this.viewModel.ExternalIdentifierMapNewName = "Experiment0";
+            Assert.IsTrue(this.viewModel.CreateNewMappingConfigurationChecked);
+            this.viewModel.SelectedExternalIdentifierMap = this.viewModel.AvailableExternalIdentifierMap.First();
+            Assert.IsFalse(this.viewModel.CreateNewMappingConfigurationChecked);
+            this.viewModel.CreateNewMappingConfigurationChecked = true;
+            Assert.IsNull(this.viewModel.SelectedExternalIdentifierMap);
+        }
+
+        [Test]
+        public void VerifyConnectCommand()
+        {
+            Assert.IsFalse(this.viewModel.ConnectCommand.CanExecute(null));
+            this.viewModel.SelectedExternalIdentifierMap = this.viewModel.AvailableExternalIdentifierMap.First();
+            Assert.IsTrue(this.viewModel.ConnectCommand.CanExecute(null));
+            this.viewModel.SelectedExternalIdentifierMap = null;
+            this.viewModel.ExternalIdentifierMapNewName = "new Name";
+            Assert.IsTrue(this.viewModel.ConnectCommand.CanExecute(null));
+            Assert.DoesNotThrow(() => this.viewModel.ConnectCommand.Execute(null));
+            this.closeWindowBehavior.Verify(x => x.Close(), Times.Once);
+            this.dstController.VerifySet(x => x.ExternalIdentifierMap = It.IsAny<ExternalIdentifierMap>(), Times.Once());
+        }
+        
+        [Test]
+        public void VerifyCancelCommand()
+        {
+            Assert.IsTrue(this.viewModel.CancelCommand.CanExecute(null));
+            Assert.DoesNotThrow(() => this.viewModel.CancelCommand.Execute(null));
+            this.closeWindowBehavior.Verify(x => x.Close(), Times.Once);
+        }
+    }
+}

--- a/DEHCATIA.Tests/ViewModels/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
@@ -91,7 +91,13 @@ namespace DEHCATIA.Tests.ViewModels.Dialogs
             };
 
             this.product0 = new Mock<Product>();
+            this.product0.Setup(x => x.get_DescriptionRef()).Returns(string.Empty);
+            this.product0.Setup(x => x.get_PartNumber()).Returns(string.Empty);
+            this.product0.Setup(x => x.get_Name()).Returns(string.Empty);
             this.product1 = new Mock<Product>();
+            this.product1.Setup(x => x.get_DescriptionRef()).Returns(string.Empty);
+            this.product1.Setup(x => x.get_PartNumber()).Returns(string.Empty);
+            this.product1.Setup(x => x.get_Name()).Returns(string.Empty);
 
             this.rootElement = new ElementRowViewModel(this.product0.Object, string.Empty)
             {
@@ -112,7 +118,7 @@ namespace DEHCATIA.Tests.ViewModels.Dialogs
             this.hubController.Setup(x => x.GetSiteDirectory()).Returns(new SiteDirectory());
 
             this.dstController = new Mock<IDstController>();
-            this.dstController.Setup(x => x.Map(It.IsAny<List<ElementRowViewModel>>()));
+            this.dstController.Setup(x => x.Map(It.IsAny<ElementRowViewModel>()));
         
             this.statusBar = new Mock<IStatusBarControlViewModel>();
 
@@ -151,11 +157,11 @@ namespace DEHCATIA.Tests.ViewModels.Dialogs
 
             this.viewModel.CloseWindowBehavior = this.closeBehavior.Object;
             this.viewModel.ContinueCommand.Execute(null);
-            this.dstController.Setup(x => x.Map(It.IsAny<List<ElementRowViewModel>>())).Throws<InvalidOperationException>();
+            this.dstController.Setup(x => x.Map(It.IsAny<ElementRowViewModel>())).Throws<InvalidOperationException>();
             this.viewModel.ContinueCommand.Execute(null);
 
             this.closeBehavior.Verify(x => x.Close(), Times.Once);
-            this.dstController.Verify(x => x.Map(It.IsAny<List<ElementRowViewModel>>()), Times.Exactly(2));
+            this.dstController.Verify(x => x.Map(It.IsAny<ElementRowViewModel>()), Times.Exactly(2));
         }
     }
 }

--- a/DEHCATIA.Tests/ViewModels/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
@@ -148,7 +148,7 @@ namespace DEHCATIA.Tests.ViewModels.Dialogs
         [Test]
         public void VerifyContinueCommand()
         {
-            Assert.IsFalse(this.viewModel.ContinueCommand.CanExecute(null));
+            Assert.IsTrue(this.viewModel.ContinueCommand.CanExecute(null));
             this.viewModel.SelectedThing = this.viewModel.TopElement;
             this.viewModel.TopElement.ElementDefinition = this.viewModel.AvailableElementDefinitions.FirstOrDefault();
             this.viewModel.TopElement.SelectedOption = this.viewModel.AvailableOptions.FirstOrDefault();

--- a/DEHCATIA.Tests/ViewModels/DstProductTreeViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/DstProductTreeViewModelTestFixture.cs
@@ -82,11 +82,14 @@ namespace DEHCATIA.Tests.ViewModels
         [Test]
         public void VerifyUpdateProductTree()
         {
-            this.dstController.Setup(x => x.GetProductTree(It.IsAny<CancellationToken>())).Returns(new ElementRowViewModel(this.product0.Object, string.Empty));
+            this.dstController.Setup(x => x.GetProductTree(It.IsAny<CancellationToken>()));
+            this.dstController.Setup(x => x.ProductTree).Returns(new ElementRowViewModel(this.product1.Object, string.Empty));
             this.dstController.Setup(x => x.IsCatiaConnected).Returns(true);
-            this.viewModel = new DstProductTreeViewModel(this.dstController.Object, this.statusBar.Object, this.navigationService.Object, this.hubController.Object);
-            this.statusBar.Verify(x => x.Append(It.IsAny<string>(), It.IsAny<StatusBarMessageSeverity>()), Times.Exactly(2));
-            Assert.AreEqual(1, this.viewModel.RootElements.Count);
+            this.statusBar.Setup(x => x.Append(It.IsAny<string>(), StatusBarMessageSeverity.Info));
+ 
+             this.viewModel = new DstProductTreeViewModel(this.dstController.Object, this.statusBar.Object, this.navigationService.Object, this.hubController.Object);
+            this.statusBar.Verify(x => x.Append(It.IsAny<string>(), StatusBarMessageSeverity.Info), Times.Exactly(2));
+            Assert.IsNotNull(this.viewModel.RootElement);
         }
     }
 }

--- a/DEHCATIA.Tests/ViewModels/DstProductTreeViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/DstProductTreeViewModelTestFixture.cs
@@ -26,6 +26,7 @@ namespace DEHCATIA.Tests.ViewModels
 {
     using System.Reactive.Concurrency;
     using System.Threading;
+    using System.Threading.Tasks;
 
     using DEHCATIA.DstController;
     using DEHCATIA.ViewModels;
@@ -80,14 +81,16 @@ namespace DEHCATIA.Tests.ViewModels
         }
 
         [Test]
-        public void VerifyUpdateProductTree()
+        public async Task VerifyUpdateProductTree()
         {
             this.dstController.Setup(x => x.GetProductTree(It.IsAny<CancellationToken>()));
             this.dstController.Setup(x => x.ProductTree).Returns(new ElementRowViewModel(this.product1.Object, string.Empty));
             this.dstController.Setup(x => x.IsCatiaConnected).Returns(true);
             this.statusBar.Setup(x => x.Append(It.IsAny<string>(), StatusBarMessageSeverity.Info));
  
-             this.viewModel = new DstProductTreeViewModel(this.dstController.Object, this.statusBar.Object, this.navigationService.Object, this.hubController.Object);
+            this.viewModel = new DstProductTreeViewModel(this.dstController.Object, this.statusBar.Object, this.navigationService.Object, this.hubController.Object);
+            
+            await Task.Delay(1);
             this.statusBar.Verify(x => x.Append(It.IsAny<string>(), StatusBarMessageSeverity.Info), Times.Exactly(2));
             Assert.IsNotNull(this.viewModel.RootElement);
         }

--- a/DEHCATIA.Tests/ViewModels/HubDataSourceViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/HubDataSourceViewModelTestFixture.cs
@@ -60,6 +60,7 @@ namespace DEHCATIA.Tests.ViewModels
 
         private IHubDataSourceViewModel viewModel;
         private Mock<IDstController> dstController;
+        private Mock<IHubSessionControlViewModel> sessionControl;
 
         [SetUp]
         public void Setup()
@@ -76,6 +77,7 @@ namespace DEHCATIA.Tests.ViewModels
             this.objectBrowser.Setup(x => x.CanMap).Returns(new Mock<IObservable<bool>>().Object);
             this.objectBrowser.Setup(x => x.MapCommand).Returns(ReactiveCommand.Create());
             this.objectBrowser.Setup(x => x.Things).Returns(new ReactiveList<BrowserViewModelBase>());
+            this.objectBrowser.Setup(x => x.SelectedThings).Returns(new ReactiveList<object>());
 
             this.publicationBrowser = new Mock<IPublicationBrowserViewModel>();
 
@@ -83,10 +85,11 @@ namespace DEHCATIA.Tests.ViewModels
 
             this.hubBrowserHeader = new Mock<IHubBrowserHeaderViewModel>();
             this.dstController = new Mock<IDstController>();
+            this.sessionControl = new Mock<IHubSessionControlViewModel>();
 
             this.viewModel = new HubDataSourceViewModel(this.navigationService.Object, this.hubController.Object, 
                 this.objectBrowser.Object, this.publicationBrowser.Object, this.hubBrowserHeader.Object,
-                this.dstController.Object);
+                this.dstController.Object, this.sessionControl.Object);
         }
 
         [Test]

--- a/DEHCATIA.Tests/ViewModels/MainWindowViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/MainWindowViewModelTestFixture.cs
@@ -49,6 +49,8 @@ namespace DEHCATIA.Tests.ViewModels
         private Mock<INavigationService> navigationService;
         private Mock<ITransferControlViewModel> transferControl;
         private Mock<IDstController> dstController;
+        private Mock<IDstNetChangePreviewViewModel> dstNetChangePreview;
+        private Mock<IHubNetChangePreviewViewModel> hubNetChangePreview;
 
         [SetUp]
         public void Setup()
@@ -59,9 +61,12 @@ namespace DEHCATIA.Tests.ViewModels
             this.navigationService = new Mock<INavigationService>();
             this.transferControl = new Mock<ITransferControlViewModel>();
             this.dstController = new Mock<IDstController>();
+            this.dstNetChangePreview = new Mock<IDstNetChangePreviewViewModel>();
+            this.hubNetChangePreview = new Mock<IHubNetChangePreviewViewModel>();
 
             this.viewModel = new MainWindowViewModel(this.hubDataSourceViewModel.Object, this.dstSourceViewModel.Object,
-                this.statusBarViewModel.Object, this.navigationService.Object, this.transferControl.Object, this.dstController.Object);
+                this.statusBarViewModel.Object, this.navigationService.Object, this.transferControl.Object, this.dstController.Object,
+                this.hubNetChangePreview.Object, this.dstNetChangePreview.Object);
         }
 
         [Test]

--- a/DEHCATIA.Tests/ViewModels/NetChangePreview/DstNetChangePreviewViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/NetChangePreview/DstNetChangePreviewViewModelTestFixture.cs
@@ -1,0 +1,156 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DstNetChangePreviewViewModelTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHCATIA
+// 
+//    The DEHCATIA is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHCATIA is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.Tests.ViewModels.NetChangePreview
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+
+    using CDP4Dal;
+    using CDP4Dal.Permission;
+
+    using DEHPCommon.HubController.Interfaces;
+    using DEHPCommon.Services.NavigationService;
+    using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
+    using DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows;
+
+    using DEHCATIA.DstController;
+    using DEHCATIA.Events;
+    using DEHCATIA.ViewModels.NetChangePreview;
+    using DEHCATIA.ViewModels.ProductTree.Rows;
+    using DEHCATIA.ViewModels.Rows;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using ProductStructureTypeLib;
+
+    using ReactiveUI;
+
+    [TestFixture]
+    public class DstNetChangePreviewViewModelTestFixture
+    {
+        private DstNetChangePreviewViewModel viewModel;
+        private Mock<IDstController> dstController;
+        private Mock<INavigationService> navigation;
+        private Mock<IHubController> hubController;
+        private Mock<IStatusBarControlViewModel> statusBar;
+        private Parameter parameter0;
+        private Parameter parameter1;
+        private Mock<ISession> session;
+        private ElementDefinition elementDefinition;
+        private ElementUsage elementUsage;
+        private ParameterOverride parameterOverride;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.dstController = new Mock<IDstController>();
+            this.navigation = new Mock<INavigationService>();
+            this.hubController = new Mock<IHubController>();
+            this.statusBar = new Mock<IStatusBarControlViewModel>();
+
+            this.viewModel = new DstNetChangePreviewViewModel(this.dstController.Object, 
+                this.navigation.Object, this.hubController.Object, this.statusBar.Object);
+
+            var product = new Mock<Product>();
+            product.Setup(x => x.get_DescriptionRef()).Returns(string.Empty);
+            product.Setup(x => x.get_PartNumber()).Returns(string.Empty);
+            product.Setup(x => x.get_Name()).Returns("name");
+
+            this.viewModel.RootElement = new ElementRowViewModel(product.Object, string.Empty)
+            {
+                Children = { new UsageRowViewModel(product.Object, string.Empty) }
+            };
+
+            this.parameter0 = new Parameter() { ParameterType = new BooleanParameterType()};
+            this.parameter1 = new Parameter() { ParameterType = new TextParameterType()};
+            
+            this.elementDefinition = new ElementDefinition()
+            {
+                Parameter =
+                {
+                    this.parameter0, this.parameter1
+                }
+            };
+
+            this.parameterOverride = new ParameterOverride()
+            {
+                Parameter = this.parameter1
+            };
+
+            this.elementUsage = new ElementUsage()
+            {
+                ElementDefinition = this.elementDefinition
+            };
+
+            this.dstController.Setup(x => x.HubMapResult).Returns(
+                new ReactiveList<MappedElementDefinitionRowViewModel>()
+                {
+                    new MappedElementDefinitionRowViewModel()
+                    {
+                        SelectedParameters = { this.parameter0, this.parameter1 },
+                        SelectedElement = this.elementDefinition,
+                        SelectedCatiaElement = this.viewModel.RootElements.FirstOrDefault()
+                    },
+                    new MappedElementDefinitionRowViewModel()
+                    {
+                        SelectedParameters = { this.parameterOverride },
+                        SelectedElement = this.elementUsage,
+                        SelectedCatiaElement = this.viewModel.RootElements.FirstOrDefault()?.Children.FirstOrDefault()
+                    }
+                });
+
+            this.session = new Mock<ISession>();
+            this.session.Setup(x => x.PermissionService).Returns(new Mock<IPermissionService>().Object);
+        }
+
+        [Test]
+        public void VerifyComputeValues()
+        {
+            Assert.DoesNotThrow(() => this.viewModel.UpdateTree(true));
+            Assert.DoesNotThrow(() => this.viewModel.UpdateTree(false));
+        }
+
+        [Test]
+        public void VerifyUpdateTreeBasedOnSelection()
+        {
+            this.viewModel.ComputeValues();
+            
+            Assert.DoesNotThrow(() => CDPMessageBus.Current.SendMessage(new UpdateDstPreviewBasedOnSelectionEvent(new List<ElementDefinitionRowViewModel>(), null, false )));
+            Assert.DoesNotThrow(() => CDPMessageBus.Current.SendMessage(new UpdateDstPreviewBasedOnSelectionEvent(new List<ElementDefinitionRowViewModel>(), null, true )));
+            
+            Assert.DoesNotThrow(() => CDPMessageBus.Current.SendMessage(new UpdateDstPreviewBasedOnSelectionEvent(new List<ElementDefinitionRowViewModel>()
+            {
+                new ElementDefinitionRowViewModel(
+                    new ElementDefinition() { Parameter = {this.parameter0} }, new DomainOfExpertise(), this.session.Object, null )
+            }, null, true )));
+        }
+    }
+}

--- a/DEHCATIA.Tests/ViewModels/NetChangePreview/HubNetChangePreviewViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/NetChangePreview/HubNetChangePreviewViewModelTestFixture.cs
@@ -1,0 +1,353 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="EcosimProNetChangePreviewViewModelTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHCATIA
+// 
+//    The DEHCATIA is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHCATIA is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.Tests.ViewModels.NetChangePreview
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using CDP4Dal;
+    using CDP4Dal.Permission;
+
+    using DEHPCommon.HubController.Interfaces;
+    using DEHPCommon.Services.ObjectBrowserTreeSelectorService;
+    using DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows;
+
+    using DEHCATIA.DstController;
+    using DEHCATIA.Events;
+    using DEHCATIA.ViewModels.NetChangePreview;
+    using DEHCATIA.ViewModels.ProductTree.Rows;
+    using DEHCATIA.ViewModels.Rows;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using ProductStructureTypeLib;
+
+    using ReactiveUI;
+
+    [TestFixture]
+    public class HubNetChangePreviewViewModelTestFixture
+    {
+        private Mock<IObjectBrowserTreeSelectorService> treeSelectorService;
+        private Mock<IDstController> dstController;
+        private Mock<IHubController> hubController;
+        private HubNetChangePreviewViewModel viewModel;
+        private Iteration iteration;
+        private Mock<ISession> session;
+        private Mock<IPermissionService> permissionService;
+        private Person person;
+        private DomainOfExpertise domain;
+        private TextParameterType parameterType;
+        private Participant participant;
+        private ElementDefinition elementDefinition0;
+        private ElementDefinition elementDefinition1;
+        private ElementDefinition elementDefinition2;
+        private ElementRowViewModel topElement;
+        private Parameter parameter;
+        private ParameterOverride parameterOverride;
+        private Mock<Product> product0;
+        private Mock<Product> product1;
+        private Mock<Product> product2;
+        private Mock<Product> product3;
+        private Mock<Product> product4;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.domain = new DomainOfExpertise(Guid.NewGuid(), null, null)
+            {
+                Name = "t", ShortName = "e"
+            };
+
+            this.person = new Person(Guid.NewGuid(), null, null) { GivenName = "test", DefaultDomain = this.domain };
+
+            this.participant = new Participant(Guid.NewGuid(), null, null)
+            {
+                Person = this.person
+            };
+
+            this.parameterType = new TextParameterType(Guid.NewGuid(), null, null);
+
+            var engineeringModelSetup = new EngineeringModelSetup(Guid.NewGuid(), null, null)
+            {
+                Participant = { this.participant },
+                Name = "est"
+            };
+
+            var iterationSetup = new IterationSetup(Guid.NewGuid(), null, null)
+            {
+                IterationNumber = 23
+            };
+
+            this.iteration = new Iteration(Guid.NewGuid(), null, null)
+            {
+                IterationSetup = iterationSetup
+            };
+
+            engineeringModelSetup.IterationSetup.Add(iterationSetup);
+
+            _ = new EngineeringModel()
+            {
+                Iteration = { this.iteration },
+                EngineeringModelSetup = engineeringModelSetup
+            };
+
+            this.parameter = new Parameter(Guid.NewGuid(), null,null)
+            {
+                ValueSet =
+                {
+                    new ParameterValueSet(Guid.NewGuid(), null, null)
+                    {
+                        Manual = new ValueArray<string>(new []{"2"}), ValueSwitch = ParameterSwitchKind.MANUAL
+                    }
+                },
+                ParameterType = this.parameterType
+            };
+
+            this.elementDefinition0 = new ElementDefinition(Guid.NewGuid(), null, null)
+            {
+                Parameter = { this.parameter },
+                Container = this.iteration
+            };
+
+            this.elementDefinition1 = new ElementDefinition(Guid.NewGuid(), null, null)
+            {
+                Parameter =
+                {
+                    new Parameter(Guid.NewGuid(), null,null)
+                    {
+                        ValueSet =
+                        {
+                            new ParameterValueSet(Guid.NewGuid(), null, null)
+                            {
+                                ValueSwitch = ParameterSwitchKind.COMPUTED, Computed = new ValueArray<string>()
+                            }
+                        },
+                        ParameterType = this.parameterType
+                    }
+                },
+
+                Container = this.iteration
+            };
+
+            this.parameterOverride = new ParameterOverride(Guid.NewGuid(), null, null) { Parameter = this.parameter };
+
+            this.elementDefinition2 = new ElementDefinition(Guid.NewGuid(), null, null)
+            {
+                Container = this.iteration, ContainedElement =
+                {
+                    new ElementUsage(Guid.NewGuid(), null, null)
+                    {
+                        ElementDefinition = this.elementDefinition1,
+                        ParameterOverride = { this.parameterOverride}
+                    },
+                }
+            };
+
+            this.iteration.Element.AddRange(new List<ElementDefinition>()
+            {
+                this.elementDefinition0, 
+                this.elementDefinition2,
+                this.elementDefinition1
+            });
+
+            this.permissionService = new Mock<IPermissionService>();
+            this.permissionService.Setup(x => x.CanRead(It.IsAny<Thing>())).Returns(true);
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<Thing>())).Returns(true);
+            this.permissionService.Setup(x => x.CanWrite(It.IsAny<ClassKind>(),It.IsAny<Thing>())).Returns(true);
+            
+            this.hubController = new Mock<IHubController>();
+
+            this.hubController.Setup(x => x.OpenIteration).Returns(this.iteration);
+            this.hubController.Setup(x => x.IsSessionOpen).Returns(true);
+            this.session = new Mock<ISession>();
+            this.session.Setup(x => x.ActivePerson).Returns(this.person);
+            this.session.Setup(x => x.DataSourceUri).Returns("t://es.t");
+            this.session.Setup(x => x.PermissionService).Returns(this.permissionService.Object);
+            
+            this.session.Setup(x => x.OpenIterations).Returns(
+                new ReadOnlyDictionary<Iteration, Tuple<DomainOfExpertise, Participant>>(
+                    new Dictionary<Iteration, Tuple<DomainOfExpertise, Participant>>()
+                    {
+                        { 
+                            this.iteration, 
+                            new Tuple<DomainOfExpertise, Participant>(this.domain, this.participant)
+                        }
+                    }));
+
+            this.hubController.Setup(x => x.Session).Returns(this.session.Object);
+            this.hubController.Setup(x => x.Reload()).Returns(Task.CompletedTask);
+            
+            this.dstController = new Mock<IDstController>();
+            
+            this.product0 = new Mock<Product>();
+            this.product0.Setup(x => x.get_DescriptionRef()).Returns(string.Empty);
+            this.product0.Setup(x => x.get_PartNumber()).Returns(string.Empty);
+            this.product0.Setup(x => x.get_Name()).Returns(string.Empty);
+            this.product1 = new Mock<Product>();
+            this.product1.Setup(x => x.get_DescriptionRef()).Returns(string.Empty);
+            this.product1.Setup(x => x.get_PartNumber()).Returns(string.Empty);
+            this.product1.Setup(x => x.get_Name()).Returns(string.Empty);
+            this.product2 = new Mock<Product>();
+            this.product2.Setup(x => x.get_DescriptionRef()).Returns(string.Empty);
+            this.product2.Setup(x => x.get_PartNumber()).Returns(string.Empty);
+            this.product2.Setup(x => x.get_Name()).Returns(string.Empty);
+            this.product3 = new Mock<Product>();
+            this.product3.Setup(x => x.get_DescriptionRef()).Returns(string.Empty);
+            this.product3.Setup(x => x.get_PartNumber()).Returns(string.Empty);
+            this.product3.Setup(x => x.get_Name()).Returns(string.Empty);
+            this.product4 = new Mock<Product>();
+            this.product4.Setup(x => x.get_DescriptionRef()).Returns(string.Empty);
+            this.product4.Setup(x => x.get_PartNumber()).Returns(string.Empty);
+            this.product4.Setup(x => x.get_Name()).Returns(string.Empty);
+
+            this.dstController.Setup(x => x.DstMapResult)
+                .Returns(new ReactiveList<(ElementRowViewModel, ElementBase)>() 
+                {
+                    (
+                        new ElementRowViewModel(this.product0.Object, string.Empty),
+                        new ElementDefinition(this.iteration.Element.First().Iid, null, null)
+                        {
+                            Parameter =
+                            {
+                                new Parameter(this.iteration.Element.First().Parameter.First().Iid, null, null)
+                                {
+                                    ValueSet =
+                                    {
+                                        new ParameterValueSet(this.iteration.Element.First().Parameter.First().ValueSet.First().Iid, null, null)
+                                        {
+                                            ValueSwitch = ParameterSwitchKind.COMPUTED, Computed = new ValueArray<string>(new []{"42"})
+                                        }
+                                    },
+                                    ParameterType = this.parameterType
+                                }
+                            },
+                            Container = this.iteration
+                        }
+                    ),
+                    (
+                        new ElementRowViewModel(this.product1.Object, string.Empty),
+                        new ElementDefinition(this.iteration.Element.Last().Iid, null, null)
+                        {
+                            Parameter =
+                            {
+                                new Parameter()
+                                {
+                                    ValueSet =
+                                    {
+                                        new ParameterValueSet(Guid.NewGuid(), null, null)
+                                        {
+                                            ValueSwitch = ParameterSwitchKind.COMPUTED, Computed = new ValueArray<string>(new []{"51"})
+                                        }
+                                    },
+                                    ParameterType = this.parameterType
+                                }
+                            },
+                            Container = this.iteration
+                        }
+                    ),
+                    (
+                        new ElementRowViewModel(this.product2.Object, string.Empty),
+                        this.elementDefinition0
+                    ),
+                    (
+                        new ElementRowViewModel(this.product3.Object, string.Empty),
+                        new ElementUsage(this.elementDefinition2.ContainedElement.First().Iid, null, null)
+                        {
+                            Container = this.elementDefinition1,
+                            ElementDefinition = this.elementDefinition1,
+                            ParameterOverride =
+                            {
+                                this.parameterOverride
+                            }
+                        }
+                    )
+                });
+
+            this.topElement = new ElementRowViewModel(this.product4.Object, string.Empty) { ElementDefinition = this.elementDefinition0 };
+            
+            this.treeSelectorService = new Mock<IObjectBrowserTreeSelectorService>();
+            this.treeSelectorService.Setup(x => x.ThingKinds).Returns(new List<Type>() { typeof(ElementDefinition) });
+            this.viewModel = new HubNetChangePreviewViewModel(this.hubController.Object, this.treeSelectorService.Object, this.dstController.Object);
+        }
+
+        /// <summary>
+        /// Bumping up code coverage
+        /// </summary>
+        [Test]
+        public void VerifyComputeValues()
+        {
+            var elements = this.viewModel.Things.First().ContainedRows;
+            Assert.AreEqual(1,this.viewModel.Things.Count);
+            Assert.AreEqual(3,elements.Count);
+            Assert.DoesNotThrow(() => this.viewModel.ComputeValues());
+            Assert.AreEqual(3, elements.Count);
+
+            var parameterRowViewModels = elements.First(x => x.Thing.Iid == this.elementDefinition0.Iid)
+                .ContainedRows.OfType<ParameterRowViewModel>();
+
+            Assert.AreEqual("2", parameterRowViewModels.First().Value);
+            
+            var lastElementParameters = elements.First(x => x.Thing.Iid == this.elementDefinition1.Iid)
+                .ContainedRows.OfType<ParameterRowViewModel>();
+            
+            Assert.AreEqual(1, lastElementParameters.Count());
+
+            CDPMessageBus.Current.ClearSubscriptions();
+        }
+
+        [Test]
+        public void VerifyContextMenu()
+        {
+            this.viewModel.PopulateContextMenu();
+            Assert.IsEmpty(this.viewModel.ContextMenu);
+        }
+
+        [Test]
+        public void VerifyUpdateTree()
+        {
+            Assert.DoesNotThrow(() =>this.viewModel.UpdateTree(false));
+            Assert.DoesNotThrow(() =>this.viewModel.UpdateTree(true));
+        }
+        
+        [Test]
+        public void VerifyUpdateTreeBasedOnSelection()
+        {
+            this.viewModel.ComputeValues();
+            Assert.DoesNotThrow(() => CDPMessageBus.Current.SendMessage(new UpdateHubPreviewBasedOnSelectionEvent(new []{this.topElement}, null, false)));
+            Assert.DoesNotThrow(() => CDPMessageBus.Current.SendMessage(new UpdateHubPreviewBasedOnSelectionEvent(new List<ElementRowViewModel>(), null, true)));
+        }
+    }
+}

--- a/DEHCATIA.Tests/ViewModels/NetChangePreview/HubNetChangePreviewViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/NetChangePreview/HubNetChangePreviewViewModelTestFixture.cs
@@ -47,7 +47,6 @@ namespace DEHCATIA.Tests.ViewModels.NetChangePreview
     using DEHCATIA.Events;
     using DEHCATIA.ViewModels.NetChangePreview;
     using DEHCATIA.ViewModels.ProductTree.Rows;
-    using DEHCATIA.ViewModels.Rows;
 
     using Moq;
 

--- a/DEHCATIA/App.xaml.cs
+++ b/DEHCATIA/App.xaml.cs
@@ -39,6 +39,7 @@ namespace DEHCATIA
     using DEHCATIA.ViewModels.Dialogs;
     using DEHCATIA.ViewModels.Dialogs.Interfaces;
     using DEHCATIA.ViewModels.Interfaces;
+    using DEHCATIA.ViewModels.NetChangePreview;
     using DEHCATIA.Views;
 
     using DEHPCommon;
@@ -154,6 +155,9 @@ namespace DEHCATIA
             containerBuilder.RegisterType<DstProductTreeViewModel>().As<IDstProductTreeViewModel>().SingleInstance();
             containerBuilder.RegisterType<CatiaTransferControlViewModel>().As<ITransferControlViewModel>().SingleInstance();
             containerBuilder.RegisterType<DstMappingConfigurationDialogViewModel>().As<IDstMappingConfigurationDialogViewModel>();
+            containerBuilder.RegisterType<HubNetChangePreviewViewModel>().As<IHubNetChangePreviewViewModel>().SingleInstance();
+            containerBuilder.RegisterType<DstNetChangePreviewViewModel>().As<IDstNetChangePreviewViewModel>().SingleInstance();
+            containerBuilder.RegisterType<DstLoginViewModel>().As<IDstLoginViewModel>();
         }
     }   
 }

--- a/DEHCATIA/DEHCATIA.csproj
+++ b/DEHCATIA/DEHCATIA.csproj
@@ -96,7 +96,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-    <PackageReference Include="DEHPCommon" Version="1.0.195" />
+    <PackageReference Include="DEHPCommon" Version="1.0.212" />
     <PackageReference Include="NLog" Version="4.6.8" />
     <PackageReference Include="NLog.Schema" Version="4.6.8" />
     <PackageReference Include="reactiveui" Version="6.5.0" />

--- a/DEHCATIA/DstController/DstController.cs
+++ b/DEHCATIA/DstController/DstController.cs
@@ -375,7 +375,6 @@ namespace DEHCATIA.DstController
         /// <param name="cancelToken">The <see cref="CancellationToken"/></param>
         public void GetProductTree(CancellationToken cancelToken)
         {
-            //this.ProductTree = null;
             this.ProductTree = this.catiaComService.GetProductTree(cancelToken);
         }
 
@@ -648,7 +647,7 @@ namespace DEHCATIA.DstController
             var externalId = $"{this.fromDstToHubIndicator}{element.Name}";
 
             this.ExternalIdentifierMap.Correspondence.RemoveAll(x => x.ExternalId.Equals(externalId, StringComparison.InvariantCultureIgnoreCase));
-            
+
             this.ExternalIdentifierMap.Correspondence.Add(
                 new IdCorrespondence()
                 {

--- a/DEHCATIA/DstController/IDstController.cs
+++ b/DEHCATIA/DstController/IDstController.cs
@@ -31,6 +31,7 @@ namespace DEHCATIA.DstController
     using CDP4Common.EngineeringModelData;
 
     using DEHCATIA.ViewModels.ProductTree.Rows;
+    using DEHCATIA.ViewModels.Rows;
 
     using DEHPCommon.Enumerators;
     using DEHPCommon.MappingEngine;
@@ -43,6 +44,11 @@ namespace DEHCATIA.DstController
     public interface IDstController
     {
         /// <summary>
+        /// Gets or sets value the catia ProductTree
+        /// </summary>
+        ElementRowViewModel ProductTree { get; set; }
+
+        /// <summary>
         /// Gets or sets whether there's a connection to a running CATIA client.
         /// </summary>
         bool IsCatiaConnected { get; set; }
@@ -53,6 +59,11 @@ namespace DEHCATIA.DstController
         MappingDirection MappingDirection { get; set; }
 
         /// <summary>
+        /// Gets or sets the <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        ExternalIdentifierMap ExternalIdentifierMap { get; set; }
+
+        /// <summary>
         /// Gets the colection of mapped <see cref="Parameter"/>s And <see cref="ParameterOverride"/>s through their container
         /// </summary>
         ReactiveList<(ElementRowViewModel Parent, ElementBase Element)> DstMapResult { get; }
@@ -60,14 +71,23 @@ namespace DEHCATIA.DstController
         /// <summary>
         /// Gets the colection of mapped <see cref="ElementRowViewModel"/>
         /// </summary>
-        ReactiveList<ElementRowViewModel> HubMapResult { get; }
+        ReactiveList<MappedElementDefinitionRowViewModel> HubMapResult { get; }
+
+        /// <summary>
+        /// Gets this running tool name
+        /// </summary>
+        string ThisToolName { get; }
+
+        /// <summary>
+        /// Loads the mapping configuration and generates the map result respectively
+        /// </summary>
+        void LoadMapping();
 
         /// <summary>
         /// Retrieves the product tree
         /// </summary>
         /// <param name="cancelToken">The <see cref="CancellationToken"/></param>
-        /// <returns>The root <see cref="ElementRowViewModel"/></returns>
-        ElementRowViewModel GetProductTree(CancellationToken cancelToken);
+        void GetProductTree(CancellationToken cancelToken);
 
         /// <summary>
         /// Connects to the Catia running instance
@@ -82,8 +102,8 @@ namespace DEHCATIA.DstController
         /// <summary>
         /// Map the provided collection using the corresponding rule in the assembly and the <see cref="MappingEngine"/>
         /// </summary>
-        /// <param name="dstElements">The <see cref="List{T}"/> of <see cref="ElementRowViewModel"/> data</param>
-        void Map(List<ElementRowViewModel> dstElements);
+        /// <param name="topElement">The <see cref="List{T}"/> of <see cref="ElementRowViewModel"/> data</param>
+        void Map(ElementRowViewModel topElement);
 
         /// <summary>
         /// Transfers the mapped variables to the Hub data source
@@ -96,5 +116,18 @@ namespace DEHCATIA.DstController
         /// </summary>
         /// <returns>A <see cref="Task"/></returns>
         Task UpdateParametersValueSets();
+
+        /// <summary>
+        /// Creates and sets the <see cref="DstController.ExternalIdentifierMap"/>
+        /// </summary>
+        /// <param name="newName">The model name to use for creating the new <see cref="DstController.ExternalIdentifierMap"/></param>
+        /// <returns>A newly created <see cref="DstController.ExternalIdentifierMap"/></returns>
+        ExternalIdentifierMap CreateExternalIdentifierMap(string newName);
+
+        /// <summary>
+        /// Saves the mapping to the <see cref="IDstController.ExternalIdentifierMap"/>
+        /// </summary>
+        /// <param name="topElement">The <see cref="ElementRowViewModel"/> that holds the mapping information</param>
+        void SaveTheMapping(ElementRowViewModel topElement);
     }
 }

--- a/DEHCATIA/DstController/IDstController.cs
+++ b/DEHCATIA/DstController/IDstController.cs
@@ -44,6 +44,11 @@ namespace DEHCATIA.DstController
     public interface IDstController
     {
         /// <summary>
+        /// Gets or sets the ready to map <see cref="ElementRowViewModel"/> resulting of the automapping done by the <see cref="LoadMapping"/>
+        /// </summary>
+        ElementRowViewModel ReadyToMapTopElement { get; set; }
+
+        /// <summary>
         /// Gets or sets value the catia ProductTree
         /// </summary>
         ElementRowViewModel ProductTree { get; set; }
@@ -77,6 +82,11 @@ namespace DEHCATIA.DstController
         /// Gets this running tool name
         /// </summary>
         string ThisToolName { get; }
+
+        /// <summary>
+        /// Disconnect and reconnect to the Catia product tree
+        /// </summary>
+        void Reconnect();
 
         /// <summary>
         /// Loads the mapping configuration and generates the map result respectively
@@ -127,7 +137,7 @@ namespace DEHCATIA.DstController
         /// <summary>
         /// Saves the mapping to the <see cref="IDstController.ExternalIdentifierMap"/>
         /// </summary>
-        /// <param name="topElement">The <see cref="ElementRowViewModel"/> that holds the mapping information</param>
-        void SaveTheMapping(ElementRowViewModel topElement);
+        /// <param name="element">The <see cref="ElementRowViewModel"/> that holds the mapping information</param>
+        void SaveElementMapping(ElementRowViewModel element);
     }
 }

--- a/DEHCATIA/Events/DstHighlightEvent.cs
+++ b/DEHCATIA/Events/DstHighlightEvent.cs
@@ -1,0 +1,55 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DstHighlightEvent.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.Events
+{
+    using CDP4Dal;
+
+    /// <summary>
+    /// An event for <see cref="CDPMessageBus"/>
+    /// </summary>
+    public class DstHighlightEvent
+    {
+        /// <summary>
+        /// A Value indicating whether the higlighting of the target should be canceled
+        /// </summary>
+        public bool ShouldHighlight { get; }
+
+        /// <summary>
+        /// The target thing id
+        /// </summary>
+        public object TargetThingId { get; }
+
+        /// <summary>
+        /// Initializes a new <see cref="DstHighlightEvent"/>
+        /// </summary>
+        /// <param name="targetId">The target thing id</param>
+        /// <param name="shouldHighlight">A Value indicating whether the higlighting of the target should be canceled</param>
+        public DstHighlightEvent(object targetId, bool shouldHighlight = true)
+        {
+            this.TargetThingId = targetId;
+            this.ShouldHighlight = shouldHighlight;
+        }
+    }
+}

--- a/DEHCATIA/Events/UpdateDstPreviewBasedOnSelectionEvent.cs
+++ b/DEHCATIA/Events/UpdateDstPreviewBasedOnSelectionEvent.cs
@@ -1,0 +1,50 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="UpdateDstPreviewBasedOnSelectionEvent.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.Events
+{
+    using System.Collections.Generic;
+
+    using DEHCATIA.ViewModels.Interfaces;
+
+    using DEHPCommon.Events;
+    using DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows;
+
+    /// <summary>
+    /// Event for the <see cref="CDP4Dal.CDPMessageBus"/> that allows listener to be notified
+    /// The <see cref="UpdateDstPreviewBasedOnSelectionEvent"/> is for filtering the dst impact view based on a selection
+    /// </summary>
+    public class UpdateDstPreviewBasedOnSelectionEvent : UpdatePreviewBasedOnSelectionBaseEvent<ElementDefinitionRowViewModel, IDstNetChangePreviewViewModel>
+    {
+        /// <summary>
+        /// Initializes a new <see cref="T:DEHPCommon.Events.UpdatePreviewBasedOnSelectionBaseEvent`2" />
+        /// </summary>
+        /// <param name="things">The collection of <see cref="ElementDefinitionRowViewModel"/> selection</param>
+        /// <param name="target">The target <see cref="T:System.Type" /></param>
+        /// <param name="reset">a value indicating whether the listener should reset its tree</param>
+        public UpdateDstPreviewBasedOnSelectionEvent(IEnumerable<ElementDefinitionRowViewModel> things, IDstNetChangePreviewViewModel target, bool reset) : base(things, target, reset)
+        {
+        }
+    }
+}

--- a/DEHCATIA/Events/UpdateHubPreviewBasedOnSelectionEvent.cs
+++ b/DEHCATIA/Events/UpdateHubPreviewBasedOnSelectionEvent.cs
@@ -1,0 +1,50 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="UpdateHubPreviewBasedOnSelectionEvent.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.Events
+{
+    using System.Collections.Generic;
+
+    using DEHCATIA.ViewModels.Interfaces;
+    using DEHCATIA.ViewModels.ProductTree.Rows;
+
+    using DEHPCommon.Events;
+
+    /// <summary>
+    /// Event for the <see cref="CDP4Dal.CDPMessageBus"/> that allows listener to be notified
+    /// The <see cref="UpdateHubPreviewBasedOnSelectionEvent"/> is for filtering the hub impact view based on a selection
+    /// </summary>
+    public class UpdateHubPreviewBasedOnSelectionEvent : UpdatePreviewBasedOnSelectionBaseEvent<ElementRowViewModel, IHubNetChangePreviewViewModel>
+    {
+        /// <summary>
+        /// Initializes a new <see cref="T:DEHPCommon.Events.UpdatePreviewBasedOnSelectionBaseEvent`2" />
+        /// </summary>
+        /// <param name="things">The collection of <see cref="ElementRowViewModel" /> selection</param>
+        /// <param name="target">The target <see cref="T:System.Type" /></param>
+        /// <param name="reset">a value indicating whether the listener should reset its tree</param>
+        public UpdateHubPreviewBasedOnSelectionEvent(IEnumerable<ElementRowViewModel> things, IHubNetChangePreviewViewModel target, bool reset) : base(things, target, reset)
+        {
+        }
+    }
+}

--- a/DEHCATIA/MappingRules/CatiaProductToElementRule.cs
+++ b/DEHCATIA/MappingRules/CatiaProductToElementRule.cs
@@ -60,6 +60,11 @@ namespace DEHCATIA.MappingRules
         /// The <see cref="IHubController"/>
         /// </summary>
         private readonly IHubController hubController = AppContainer.Container.Resolve<IHubController>();
+
+        /// <summary>
+        /// The <see cref="IDstController"/>
+        /// </summary>
+        private IDstController dstController;
         
         /// <summary>
         /// The <see cref="IParameterTypeService"/>
@@ -94,7 +99,8 @@ namespace DEHCATIA.MappingRules
             try
             {
                 this.owner = this.hubController.CurrentDomainOfExpertise;
-                
+                this.dstController = AppContainer.Container.Resolve<IDstController>();
+
                 this.Map(new List<ElementRowViewModel>{input});
 
                 return this.ruleOutput;
@@ -125,6 +131,7 @@ namespace DEHCATIA.MappingRules
                     usageRow.ElementDefinition = this.MapDefinitionRowViewModel(definitionRow);
                     this.MapElementUsage(usageRow);
                     this.MapParameters(usageRow);
+                    this.dstController.SaveElementMapping(usageRow);
                     this.ruleOutput.Add((usageRow.Parent, usageRow.ElementUsage));
                 }
                 else
@@ -174,7 +181,7 @@ namespace DEHCATIA.MappingRules
         {
             this.MapElementDefinition(elementRowViewModel);
             this.ruleOutput.Add((elementRowViewModel.Parent, elementRowViewModel.ElementDefinition));
-            AppContainer.Container.Resolve<IDstController>().SaveElementMapping(elementRowViewModel);
+            this.dstController.SaveElementMapping(elementRowViewModel);
         }
 
         /// <summary>

--- a/DEHCATIA/MappingRules/CatiaProductToElementRule.cs
+++ b/DEHCATIA/MappingRules/CatiaProductToElementRule.cs
@@ -44,15 +44,12 @@ namespace DEHCATIA.MappingRules
     using DEHPCommon.HubController.Interfaces;
     using DEHPCommon.MappingRules.Core;
 
-    using DevExpress.Xpf.NavBar;
-    using DevExpress.Xpo.Helpers;
-
     using NLog;
 
     /// <summary>
     /// Rule definition that transforms a collection of <see cref="ElementRowViewModel"/> to a collection <see cref="ElementDefinition"/>
     /// </summary>
-    public class CatiaProductToElementRule : MappingRule<List<ElementRowViewModel>, List<(ElementRowViewModel Parent, ElementBase Element)>>
+    public class CatiaProductToElementRule : MappingRule<ElementRowViewModel, List<(ElementRowViewModel Parent, ElementBase Element)>>
     {
         /// <summary>
         /// The current class logger
@@ -63,7 +60,7 @@ namespace DEHCATIA.MappingRules
         /// The <see cref="IHubController"/>
         /// </summary>
         private readonly IHubController hubController = AppContainer.Container.Resolve<IHubController>();
-
+        
         /// <summary>
         /// The <see cref="IParameterTypeService"/>
         /// </summary>
@@ -92,13 +89,15 @@ namespace DEHCATIA.MappingRules
         /// <summary>
         /// Transforms <see cref="!:TInput" /> to a <see cref="!:TOutput" />
         /// </summary>
-        public override List<(ElementRowViewModel Parent, ElementBase Element)> Transform(List<ElementRowViewModel> input)
+        public override List<(ElementRowViewModel Parent, ElementBase Element)> Transform(ElementRowViewModel input)
         {
             try
             {
                 this.owner = this.hubController.CurrentDomainOfExpertise;
                 
-                this.Map(input);
+                this.Map(new List<ElementRowViewModel>{input});
+
+                AppContainer.Container.Resolve<IDstController>().SaveTheMapping(input);
 
                 return this.ruleOutput;
             }

--- a/DEHCATIA/ViewModels/CatiaTransferControlViewModel.cs
+++ b/DEHCATIA/ViewModels/CatiaTransferControlViewModel.cs
@@ -146,8 +146,6 @@ namespace DEHCATIA.ViewModels
         /// <returns>A <see cref="Task"/></returns>
         private async Task CancelTransfer()
         {
-            this.dstController.DstMapResult.Clear();
-            this.dstController.HubMapResult.Clear();
             this.exchangeHistoryService.ClearPending();
             await Task.Delay(1);
             CDPMessageBus.Current.SendMessage(new UpdateDstElementTreeEvent(true));
@@ -168,7 +166,6 @@ namespace DEHCATIA.ViewModels
             this.IsIndeterminate = true;
             this.statusBar.Append($"Transfers in progress");
             await this.dstController.TransferMappedThingsToHub();
-            //this.dstController.TransferMappedThingsToDst();
             await this.exchangeHistoryService.Write();
             timer.Stop();
             this.statusBar.Append($"Transfers completed in {timer.ElapsedMilliseconds} ms");

--- a/DEHCATIA/ViewModels/Dialogs/DstLoginViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/DstLoginViewModel.cs
@@ -1,0 +1,220 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DstLoginViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2020 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed.
+// 
+//    This file is part of DEHCATIA
+// 
+//    The DEHCATIA is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHCATIA is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.ViewModels.Dialogs
+{
+    using System;
+
+    using CDP4Common.EngineeringModelData;
+
+    using DEHPCommon.HubController.Interfaces;
+    using DEHPCommon.UserInterfaces.Behaviors;
+    using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
+    using DEHPCommon.UserPreferenceHandler.UserPreferenceService;
+
+    using DEHCATIA.DstController;
+    using DEHCATIA.ViewModels.Dialogs.Interfaces;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// The view-model for the Login that allows users to connect to a OPC UA datasource
+    /// </summary>
+    public class DstLoginViewModel : ReactiveObject, IDstLoginViewModel, ICloseWindowViewModel
+    {
+        /// <summary>
+        /// The <see cref="IDstController"/> instance
+        /// </summary>
+        private readonly IDstController dstController;
+        
+        /// <summary>
+        /// Backing field for <see cref="IsBusy"/>
+        /// </summary>
+        private bool isBusy;
+
+        /// <summary>
+        /// Gets or sets the assert indicating whether the view is busy
+        /// </summary>
+        public bool IsBusy
+        {
+            get => this.isBusy;
+            set => this.RaiseAndSetIfChanged(ref this.isBusy, value);
+        }
+
+        /// <summary>
+        /// Backing field for the <see cref="LoginSuccessful"/> property
+        /// </summary>
+        private bool loginSuccessful;
+
+        /// <summary>
+        /// Gets or sets login succesfully flag
+        /// </summary>
+        public bool LoginSuccessful
+        {
+            get => this.loginSuccessful;
+            private set => this.RaiseAndSetIfChanged(ref this.loginSuccessful, value);
+        }
+
+        /// <summary>
+        /// Gets the connection command
+        /// </summary>
+        public ReactiveCommand<object> ConnectCommand { get; private set; }
+
+        /// <summary>
+        /// Gets the cancel command
+        /// </summary>
+        public ReactiveCommand<object> CancelCommand { get; private set; }
+        
+        /// <summary>
+        /// Gets or sets the <see cref="ICloseWindowBehavior"/> instance
+        /// </summary>
+        public ICloseWindowBehavior CloseWindowBehavior { get; set; }
+
+        /// <summary>
+        /// Backing field for <see cref="SelectedExternalIdentifierMap"/>
+        /// </summary>
+        private ExternalIdentifierMap selectedExternalIdentifierMap;
+
+        /// <summary>
+        /// Gets or sets the selected <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        public ExternalIdentifierMap SelectedExternalIdentifierMap
+        {
+            get => this.selectedExternalIdentifierMap;
+            set => this.RaiseAndSetIfChanged(ref this.selectedExternalIdentifierMap, value);
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="ExternalIdentifierMapNewName"/>
+        /// </summary>
+        private string externalIdentifierMapNewName;
+
+        /// <summary>
+        /// Gets or sets the name for creating a new <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        public string ExternalIdentifierMapNewName
+        {
+            get => this.externalIdentifierMapNewName;
+            set => this.RaiseAndSetIfChanged(ref this.externalIdentifierMapNewName, value);
+        }
+
+        /// <summary>
+        /// Backing field for <see cref="CreateNewMappingConfigurationChecked"/>
+        /// </summary>
+        private bool createNewMappingConfigurationChecked;
+
+        /// <summary>
+        /// Gets or sets the checked checkbox assert that selects that a new mapping configuration will be created
+        /// </summary>
+        public bool CreateNewMappingConfigurationChecked
+        {
+            get => this.createNewMappingConfigurationChecked;
+            set => this.RaiseAndSetIfChanged(ref this.createNewMappingConfigurationChecked, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ReactiveList{T}"/> of available <see cref="ExternalIdentifierMap"/>
+        /// </summary>
+        public ReactiveList<ExternalIdentifierMap> AvailableExternalIdentifierMap { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DstLoginViewModel"/> class.
+        /// </summary>
+        /// <param name="dstController">The <see cref="IDstController"/></param>
+        /// <param name="hubController">The <see cref="IHubController"/></param>
+        public DstLoginViewModel(IDstController dstController, IHubController hubController)
+        {
+            this.dstController = dstController;
+
+            this.AvailableExternalIdentifierMap = new ReactiveList<ExternalIdentifierMap>(
+                hubController.AvailableExternalIdentifierMap(this.dstController.ThisToolName));
+
+            this.WhenAnyValue(x => x.SelectedExternalIdentifierMap).Subscribe(_ =>
+            {
+                if (this.SelectedExternalIdentifierMap != null)
+                {
+                    this.CreateNewMappingConfigurationChecked = false;
+                    this.ExternalIdentifierMapNewName = null;
+                }
+            });
+            
+            this.WhenAnyValue(x => x.ExternalIdentifierMapNewName).Subscribe(_ =>
+            {
+                if (!string.IsNullOrWhiteSpace(this.ExternalIdentifierMapNewName))
+                {
+                    this.CreateNewMappingConfigurationChecked = true;
+                    this.SelectedExternalIdentifierMap = null;
+                }
+            });
+
+            var canConnect = this.WhenAnyValue(
+                vm => vm.SelectedExternalIdentifierMap,
+                vm => vm.ExternalIdentifierMapNewName,
+                ( map, mapNew) => map != null || !string.IsNullOrWhiteSpace(mapNew));
+
+            this.ConnectCommand = ReactiveCommand.Create(canConnect);
+            this.ConnectCommand.Subscribe(_ => this.ExecuteLogin());
+
+            this.CancelCommand = ReactiveCommand.Create();
+            this.CancelCommand.Subscribe(_ => this.CloseWindowBehavior?.Close());
+            
+            this.WhenAnyValue(x => x.CreateNewMappingConfigurationChecked).Subscribe(_ => this.UpdateExternalIdentifierSelectors());
+        }
+
+        /// <summary>
+        /// Updates the respective field depending on the user selection
+        /// </summary>
+        private void UpdateExternalIdentifierSelectors()
+        {
+            if (this.CreateNewMappingConfigurationChecked)
+            {
+                this.SelectedExternalIdentifierMap = null;
+            }
+            else
+            {
+                this.ExternalIdentifierMapNewName = null;
+            }
+        }
+
+        /// <summary>
+        /// Executes login command
+        /// </summary>
+        private void ExecuteLogin()
+        {
+            this.IsBusy = true;
+            this.ProcessExternalIdentifierMap();
+            this.CloseWindowBehavior?.Close();
+            this.IsBusy = false;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ExternalIdentifierMap"/> and or set the <see cref="IDstController.ExternalIdentifierMap"/>
+        /// </summary>
+        private void ProcessExternalIdentifierMap()
+        {
+            this.dstController.ExternalIdentifierMap = this.SelectedExternalIdentifierMap?.Clone(true) ??
+                                                       this.dstController.CreateExternalIdentifierMap(this.ExternalIdentifierMapNewName);
+        }
+    }
+}

--- a/DEHCATIA/ViewModels/Dialogs/DstMappingConfigurationDialogViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/DstMappingConfigurationDialogViewModel.cs
@@ -180,7 +180,10 @@ namespace DEHCATIA.ViewModels.Dialogs
 
                 if (element is UsageRowViewModel usageRow && usageRow.ElementUsage is {} && element.ElementDefinition is {} elementDefinition)
                 {
-                    usageRow.ElementUsage = elementDefinition.ContainedElement.FirstOrDefault(x => x.Iid == usageRow.ElementUsage.Iid);
+                    usageRow.ElementUsage = 
+                        this.AvailableElementDefinitions.SelectMany(d => d.ContainedElement)
+                            .Where(u => u.ElementDefinition.Iid == elementDefinition.Iid)
+                            .FirstOrDefault(x => x.Iid == usageRow.ElementUsage.Iid);
                 }
 
                 this.RefreshMappedThings(element.Children);
@@ -294,7 +297,7 @@ namespace DEHCATIA.ViewModels.Dialogs
                 elementUsages = elementUsages.Where(x => !x.ExcludeOption.Contains(option));
             }
 
-            this.AvailableElementUsages.AddRange(elementUsages); //.Select(x => x.Clone(true))
+            this.AvailableElementUsages.AddRange(elementUsages);
         }
 
         /// <summary>

--- a/DEHCATIA/ViewModels/Dialogs/DstMappingConfigurationDialogViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/DstMappingConfigurationDialogViewModel.cs
@@ -80,17 +80,17 @@ namespace DEHCATIA.ViewModels.Dialogs
         }
 
         /// <summary>
-        /// Backing field for <see cref="AreHubFieldsEditable"/>
+        /// Backing field for <see cref="CanSetAnElementUsage"/>
         /// </summary>
-        private bool areHubFieldsEditable;
+        private bool canSetAnElementUsage;
 
         /// <summary>
-        /// Gets or sets a value indicating whether the hub fields are available
+        /// Gets or sets a value indicating whether the current row has an <see cref="ElementUsage"/> representation
         /// </summary>
-        public bool AreHubFieldsEditable
+        public bool CanSetAnElementUsage
         {
-            get => this.areHubFieldsEditable;
-            set => this.RaiseAndSetIfChanged(ref this.areHubFieldsEditable, value);
+            get => this.canSetAnElementUsage;
+            set => this.RaiseAndSetIfChanged(ref this.canSetAnElementUsage, value);
         }
 
         /// <summary>
@@ -111,6 +111,11 @@ namespace DEHCATIA.ViewModels.Dialogs
         /// Gets the collection of the available <see cref="ElementDefinition"/>s from the connected Hub Model
         /// </summary>
         public ReactiveList<ElementDefinition> AvailableElementDefinitions { get; } = new ReactiveList<ElementDefinition>();
+
+        /// <summary>
+        /// Gets the collection of the available <see cref="ElementDefinition"/>s from the connected Hub Model
+        /// </summary>
+        public ReactiveList<ElementUsage> AvailableElementUsages { get; } = new ReactiveList<ElementUsage>();
 
         /// <summary>
         /// Gets the collection of the available <see cref="ActualFiniteState"/>s depending on the selected <see cref="Parameter"/>
@@ -151,8 +156,8 @@ namespace DEHCATIA.ViewModels.Dialogs
                     this.UpdateHubFields(() =>
                     {
                         this.InitializesCommandsAndObservableSubscriptions();
-                        this.RefreshMappedThings();
                         this.UpdateProperties();
+                        this.RefreshMappedThings();
                         this.CheckCanExecute();
                     });
                 });
@@ -170,34 +175,18 @@ namespace DEHCATIA.ViewModels.Dialogs
             {
                 if (element.ElementDefinition is {})
                 {
-                    element.ElementDefinition = this.GetElementBaseFromTheCache<ElementDefinition>(element.ElementDefinition.Iid);
+                    element.ElementDefinition = this.AvailableElementDefinitions.FirstOrDefault(x => x.Iid == element.ElementDefinition.Iid);
                 }
 
-                if (element is UsageRowViewModel usageRow && usageRow.ElementUsage is {})
+                if (element is UsageRowViewModel usageRow && usageRow.ElementUsage is {} && element.ElementDefinition is {} elementDefinition)
                 {
-                    usageRow.ElementUsage = this.GetElementBaseFromTheCache<ElementUsage>(usageRow.ElementUsage.Iid);
+                    usageRow.ElementUsage = elementDefinition.ContainedElement.FirstOrDefault(x => x.Iid == usageRow.ElementUsage.Iid);
                 }
 
                 this.RefreshMappedThings(element.Children);
             }
         }
-
-        /// <summary>
-        /// Tries to gets the version of the referenced thing from the cache otherwise and replace the <paramref name="iid"/> otherwise set it to null
-        /// </summary>
-        /// <typeparam name="TElement">The type of <see cref="ElementBase"/></typeparam>
-        /// <param name="iid">The iid of the <typeparamref name="TElement"/> to refresh</param>
-        /// <returns>A <see cref="TElement"/></returns>
-        private TElement GetElementBaseFromTheCache<TElement>(Guid iid) where TElement : ElementBase
-        {
-            if (this.HubController.GetThingById(iid, this.HubController.OpenIteration, out TElement element))
-            {
-                return (TElement)element.Clone(true);
-            }
-
-            return null;
-        }
-
+        
         /// <summary>
         /// Initializes this view model <see cref="ICommand"/> and <see cref="Observable"/>
         /// </summary>
@@ -230,8 +219,14 @@ namespace DEHCATIA.ViewModels.Dialogs
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(_ => this.UpdateHubFields(this.CheckCanExecute));
 
+            this.WhenAnyValue(x => x.SelectedThing.ElementDefinition)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(_ => this.UpdateHubFields(this.UpdateAvailableElementUsages));
+
             this.WhenAnyValue(x => x.SelectedThing)
-                .Subscribe(x => this.AreHubFieldsEditable = x == this.Elements.FirstOrDefault());
+                .Subscribe(_ => 
+                    this.CanSetAnElementUsage = 
+                        this.SelectedThing != null && this.SelectedThing != this.TopElement && !(this.SelectedThing is DefinitionRowViewModel));
         }
 
         /// <summary>
@@ -278,7 +273,30 @@ namespace DEHCATIA.ViewModels.Dialogs
             
             this.IsBusy = false;
         }
-        
+
+        /// <summary>
+        /// Updates the <see cref="AvailableElementUsages"/>
+        /// </summary>
+        private void UpdateAvailableElementUsages()
+        {
+            this.AvailableElementUsages.Clear();
+
+            if (!(this.SelectedThing?.ElementDefinition is { } elementDefinition) || elementDefinition.Iid == Guid.Empty)
+            {
+                return;
+            }
+
+            var elementUsages = this.AvailableElementDefinitions.SelectMany(d => d.ContainedElement)
+                .Where(u => u.ElementDefinition.Iid == elementDefinition.Iid);
+
+            if (this.SelectedThing.SelectedOption is { } option)
+            {
+                elementUsages = elementUsages.Where(x => !x.ExcludeOption.Contains(option));
+            }
+
+            this.AvailableElementUsages.AddRange(elementUsages); //.Select(x => x.Clone(true))
+        }
+
         /// <summary>
         /// Updates the <see cref="AvailableActualFiniteStates"/>
         /// </summary>

--- a/DEHCATIA/ViewModels/Dialogs/DstMappingConfigurationDialogViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/DstMappingConfigurationDialogViewModel.cs
@@ -239,7 +239,12 @@ namespace DEHCATIA.ViewModels.Dialogs
         /// </summary>
         private void ContinueCommandExecute()
         {
-            this.DstController.Map(this.Elements.ToList());
+            if (!(this.Elements.FirstOrDefault() is { } element))
+            {
+                return;
+            }
+
+            this.DstController.Map(element);
         }
 
         /// <summary>

--- a/DEHCATIA/ViewModels/Dialogs/Interfaces/IDstLoginViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/Interfaces/IDstLoginViewModel.cs
@@ -1,0 +1,39 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IDstLoginViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2020 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski, Ahmed Abulwafa Ahmed
+// 
+//    This file is part of DEHCATIA
+// 
+//    The DEHCATIA is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHCATIA is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.ViewModels.Dialogs.Interfaces
+{
+    using System.Reactive;
+
+    using DEHPCommon.UserInterfaces.Behaviors;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Interface definiton for <see cref="DstLoginViewModel"/>
+    /// </summary>
+    public interface IDstLoginViewModel
+    {
+    }
+}

--- a/DEHCATIA/ViewModels/Dialogs/Interfaces/IDstMappingConfigurationDialogViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/Interfaces/IDstMappingConfigurationDialogViewModel.cs
@@ -48,12 +48,7 @@ namespace DEHCATIA.ViewModels.Dialogs.Interfaces
         /// Gets or sets a value indicating whether <see cref="MappingConfigurationDialogViewModel.ContinueCommand"/> can execute
         /// </summary>
         bool CanContinue { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the hub fields are available
-        /// </summary>
-        bool AreHubFieldsEditable { get; set; }
-
+        
         /// <summary>
         /// Gets the collection of the available <see cref="ElementDefinition"/>s from the connected Hub Model
         /// </summary>

--- a/DEHCATIA/ViewModels/DstDataSourceViewModel.cs
+++ b/DEHCATIA/ViewModels/DstDataSourceViewModel.cs
@@ -26,11 +26,18 @@ namespace DEHCATIA.ViewModels
 {
     using System;
     using System.Reactive.Linq;
+    using System.Threading.Tasks;
+
+    using Autofac;
 
     using DEHCATIA.DstController;
+    using DEHCATIA.ViewModels.Dialogs.Interfaces;
     using DEHCATIA.ViewModels.Interfaces;
+    using DEHCATIA.Views.Dialogs;
 
+    using DEHPCommon;
     using DEHPCommon.Enumerators;
+    using DEHPCommon.HubController.Interfaces;
     using DEHPCommon.Services.NavigationService;
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
 
@@ -50,6 +57,11 @@ namespace DEHCATIA.ViewModels
         /// The <see cref="IStatusBarControlViewModel"/>
         /// </summary>
         private readonly IStatusBarControlViewModel statusBar;
+
+        /// <summary>
+        /// The <see cref="IHubController"/>
+        /// </summary>
+        private readonly IHubController hubController;
 
         /// <summary>
         /// Backing field for <see cref="ConnectionStatus"/>.
@@ -83,12 +95,14 @@ namespace DEHCATIA.ViewModels
         /// <param name="dstBrowserHeaderViewModel">The <see cref="IDstBrowserHeaderViewModel"/> instance.</param>
         /// <param name="dstProductTreeViewModel">The <see cref="IDstProductTreeViewModel"/> instance.</param>
         /// <param name="statusBar">The <see cref="IStatusBarControlViewModel"/></param>
+        /// <param name="hubController">The <see cref="IHubController"/></param>
         public DstDataSourceViewModel(INavigationService navigationService, IDstController dstController, 
             IDstBrowserHeaderViewModel dstBrowserHeaderViewModel, IDstProductTreeViewModel dstProductTreeViewModel,
-            IStatusBarControlViewModel statusBar) : base(navigationService)
+            IStatusBarControlViewModel statusBar, IHubController hubController) : base(navigationService)
         {
             this.dstController = dstController;
             this.statusBar = statusBar;
+            this.hubController = hubController;
             this.DstBrowserHeaderViewModel = dstBrowserHeaderViewModel;
             this.DstProductTreeViewModel = dstProductTreeViewModel;
 
@@ -96,6 +110,10 @@ namespace DEHCATIA.ViewModels
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(this.UpdateConnectButtonText);
 
+            this.WhenAnyValue(vm => vm.dstController.IsCatiaConnected)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(this.UpdateConnectButtonText);
+            
             this.InitializeCommands();
 
             this.ConnectionStatus = "Connection is not established";
@@ -108,8 +126,9 @@ namespace DEHCATIA.ViewModels
         {
             var canConnect = this.WhenAny(x => x.DstProductTreeViewModel.CancelToken,
                 x => x.dstController.IsCatiaConnected,
-                (x, c) => 
-                    x.Value is null || !(x.Value != null && !c.Value))
+                x => x.hubController.OpenIteration,
+                (x, c, i) => 
+                    (x.Value is null || !(x.Value != null && !c.Value)) && i.Value != null)
                 .ObserveOn(RxApp.MainThreadScheduler);
 
             this.ConnectCommand = ReactiveCommand.Create(canConnect);
@@ -134,6 +153,16 @@ namespace DEHCATIA.ViewModels
             }
             else
             {
+                var viewModel = AppContainer.Container.Resolve<IDstLoginViewModel>();
+
+                this.NavigationService.ShowDialog<DstLogin, IDstLoginViewModel>(viewModel);
+
+                if (this.dstController.ExternalIdentifierMap is null)
+                {
+                    this.statusBar.Append("Connection to CATIA has been canceled");
+                    return;
+                }
+
                 this.dstController.ConnectToCatia();
                 this.ConnectionStatus = this.dstController.IsCatiaConnected ? "Connection is established" : "CATIA is not available";
             }

--- a/DEHCATIA/ViewModels/DstProductTreeViewModel.cs
+++ b/DEHCATIA/ViewModels/DstProductTreeViewModel.cs
@@ -265,7 +265,11 @@ namespace DEHCATIA.ViewModels
                     else if (t.IsCompleted)
                     {
                         this.RootElement = this.DstController.ProductTree;
-                        this.DstController.LoadMapping();
+
+                        if (this.DstController.ProductTree != null)
+                        {
+                            this.DstController.LoadMapping();
+                        }
                     }
 
                     this.IsBusy = false;

--- a/DEHCATIA/ViewModels/Interfaces/IDstNetChangePreviewViewModel.cs
+++ b/DEHCATIA/ViewModels/Interfaces/IDstNetChangePreviewViewModel.cs
@@ -1,0 +1,37 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IDstNetChangePreviewViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHCATIA
+// 
+//    The DEHCATIA is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHCATIA is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.ViewModels.Interfaces
+{
+    using DEHCATIA.ViewModels.NetChangePreview;
+
+    using DEHPCommon.UserInterfaces.ViewModels.NetChangePreview.Interfaces;
+
+    /// <summary>
+    /// Interface definition for the <see cref="DstNetChangePreviewViewModel"/>
+    /// </summary>
+    public interface IDstNetChangePreviewViewModel : INetChangePreviewViewModel
+    {
+    }
+}

--- a/DEHCATIA/ViewModels/Interfaces/IHubNetChangePreviewViewModel.cs
+++ b/DEHCATIA/ViewModels/Interfaces/IHubNetChangePreviewViewModel.cs
@@ -1,0 +1,37 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="IHubNetChangePreviewViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHCATIA
+// 
+//    The DEHCATIA is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHCATIA is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.ViewModels.Interfaces
+{
+    using DEHCATIA.ViewModels.NetChangePreview;
+
+    using DEHPCommon.UserInterfaces.ViewModels.NetChangePreview.Interfaces;
+
+    /// <summary>
+    /// Interface definition for the <see cref="HubNetChangePreviewViewModel"/>
+    /// </summary>
+    public interface IHubNetChangePreviewViewModel : INetChangePreviewViewModel
+    {
+    }
+}

--- a/DEHCATIA/ViewModels/Interfaces/IMainWindowViewModel.cs
+++ b/DEHCATIA/ViewModels/Interfaces/IMainWindowViewModel.cs
@@ -24,8 +24,12 @@
 
 namespace DEHCATIA.ViewModels.Interfaces
 {
+    using System.Windows.Input;
+
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
     using DEHPCommon.UserInterfaces.ViewModels.NetChangePreview.Interfaces;
+
+    using ReactiveUI;
 
     /// <summary>
     /// Interface definitions of methods and properties of the application Main window
@@ -33,9 +37,14 @@ namespace DEHCATIA.ViewModels.Interfaces
     public interface IMainWindowViewModel : ISwitchLayoutPanelOrderViewModel
     {
         /// <summary>
+        /// Gets the <see cref="ITransferControlViewModel"/>
+        /// </summary>
+        ITransferControlViewModel TransferControlViewModel { get; }
+
+        /// <summary>
         /// Gets the view model that represents the net change preview panel
         /// </summary>
-        INetChangePreviewViewModel NetChangePreviewViewModel { get; }
+        IHubNetChangePreviewViewModel HubNetChangePreviewViewModel { get; }
 
         /// <summary>
         /// Gets the view model that represents the 10-25 data source
@@ -43,7 +52,7 @@ namespace DEHCATIA.ViewModels.Interfaces
         IHubDataSourceViewModel HubDataSourceViewModel { get; }
 
         /// <summary>
-        /// Gets the view model the represents the CATIA data source
+        /// Gets the view model that represents the EcosimPro data source
         /// </summary>
         IDstDataSourceViewModel DstSourceViewModel { get; }
 
@@ -51,5 +60,10 @@ namespace DEHCATIA.ViewModels.Interfaces
         /// Gets the view model that represents the status bar
         /// </summary>
         IStatusBarControlViewModel StatusBarControlViewModel { get; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="ICommand"/> that will change the mapping direction
+        /// </summary>
+        ReactiveCommand<object> ChangeMappingDirection { get; }
     }
 }

--- a/DEHCATIA/ViewModels/MainWindowViewModel.cs
+++ b/DEHCATIA/ViewModels/MainWindowViewModel.cs
@@ -73,7 +73,12 @@ namespace DEHCATIA.ViewModels
         /// <summary>
         /// Gets the view model that represents the net change preview panel
         /// </summary>
-        public INetChangePreviewViewModel NetChangePreviewViewModel { get; }
+        public IHubNetChangePreviewViewModel HubNetChangePreviewViewModel { get; }
+
+        /// <summary>
+        /// Gets the view model that represents the net change preview panel
+        /// </summary>
+        public IDstNetChangePreviewViewModel DstNetChangePreviewViewModel { get; }
 
         /// <summary>
         /// Gets the view model that represents the 10-25 data source
@@ -118,9 +123,12 @@ namespace DEHCATIA.ViewModels
         /// <param name="navigationService">The <see cref="INavigationService"/></param>
         /// <param name="transferControlViewModel">The <see cref="ITransferControlViewModel"/></param>
         /// <param name="dstController">The <see cref="IDstController"/></param>
+        /// <param name="hubNetChangePreviewViewModel">The <see cref="IHubNetChangePreviewViewModel"/></param>
+        /// <param name="dstNetChangePreviewViewModel">The <see cref="IDstNetChangePreviewViewModel"/></param>
         public MainWindowViewModel(IHubDataSourceViewModel hubDataSourceViewModel, IDstDataSourceViewModel dstSourceViewModel, 
             IStatusBarControlViewModel statusBarControlViewModel, INavigationService navigationService,
-            ITransferControlViewModel transferControlViewModel, IDstController dstController)
+            ITransferControlViewModel transferControlViewModel, IDstController dstController, 
+            IHubNetChangePreviewViewModel hubNetChangePreviewViewModel, IDstNetChangePreviewViewModel dstNetChangePreviewViewModel)
         {
             this.navigationService = navigationService;
             this.TransferControlViewModel = transferControlViewModel;
@@ -128,6 +136,8 @@ namespace DEHCATIA.ViewModels
             this.HubDataSourceViewModel = hubDataSourceViewModel;
             this.DstSourceViewModel = dstSourceViewModel;
             this.StatusBarControlViewModel = statusBarControlViewModel;
+            this.HubNetChangePreviewViewModel = hubNetChangePreviewViewModel;
+            this.DstNetChangePreviewViewModel = dstNetChangePreviewViewModel;
             this.StatusBarControlViewModel.Append($"Welcome to the DEH Catia adapter!");
             this.InitializeCommands();
         }

--- a/DEHCATIA/ViewModels/NetChangePreview/DstNetChangePreviewViewModel.cs
+++ b/DEHCATIA/ViewModels/NetChangePreview/DstNetChangePreviewViewModel.cs
@@ -1,0 +1,208 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DstNetChangePreviewViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.ViewModels.NetChangePreview
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reactive.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using CDP4Dal;
+
+    using DEHCATIA.Events;
+    using DEHCATIA.ViewModels.Interfaces;
+    using DEHCATIA.ViewModels.ProductTree.Rows;
+    using DEHCATIA.ViewModels.Rows;
+
+    using DEHPCommon.Enumerators;
+    using DEHPCommon.HubController.Interfaces;
+    using DEHPCommon.Services.NavigationService;
+    using DEHPCommon.UserInterfaces.ViewModels;
+    using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
+    using DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// View model for this dst net change preview panel
+    /// </summary>
+    public class DstNetChangePreviewViewModel : DstProductTreeViewModel, IDstNetChangePreviewViewModel
+    {
+        /// <summary>
+        /// Backing field for <see cref="PreviousRootElementState"/>
+        /// </summary>
+        private ElementRowViewModel previousRootElementState;
+
+        /// <summary>
+        /// Gets or sets the root element at a previous state
+        /// </summary>
+        public ElementRowViewModel PreviousRootElementState
+        {
+            get => this.previousRootElementState;
+            set => this.RaiseAndSetIfChanged(ref this.previousRootElementState, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating that the tree in the case that
+        /// <see cref="DstController.DstMapResult"/> is not empty and the tree is not showing all changes
+        /// </summary>
+        public bool IsDirty { get; set; }
+
+        /// <summary>
+        /// Initializes a new <see cref="DstNetChangePreviewViewModel"/>
+        /// </summary>
+        /// <param name="dstController">The <see cref="DstController.IDstController"/></param>
+        /// <param name="navigationService">The <see cref="INavigationService"/></param>
+        /// <param name="hubController">The <see cref="IHubController"/></param>
+        /// <param name="statusBar">The <see cref="IStatusBarControlViewModel"/></param>
+        public DstNetChangePreviewViewModel(DstController.IDstController dstController, INavigationService navigationService,
+            IHubController hubController, IStatusBarControlViewModel statusBar) : base(dstController, statusBar, navigationService, hubController)
+        {
+            CDPMessageBus.Current.Listen<UpdateDstElementTreeEvent>()
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(x => this.UpdateTree(x.Reset));
+
+            CDPMessageBus.Current.Listen<UpdateDstPreviewBasedOnSelectionEvent>()
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(x => this.UpdateTreeBasedOnSelectionHandler(x.Selection.ToList()));
+        }
+
+        /// <summary>
+        /// Updates the tree and filter changed things based on a selection
+        /// </summary>
+        /// <param name="selection">The collection of selected <see cref="ElementDefinitionRowViewModel"/> </param>
+        private void UpdateTreeBasedOnSelectionHandler(IReadOnlyList<ElementDefinitionRowViewModel> selection)
+        {
+            if (this.DstController.HubMapResult.Any())
+            {
+                this.IsBusy = true;
+
+                if (!selection.Any() && this.IsDirty)
+                {
+                    this.ComputeValuesWrapper();
+                }
+
+                else if (selection.Any())
+                {
+                    this.UpdateTreeBasedOnSelection(selection);
+                }
+
+                this.IsBusy = false;
+            }
+        }
+
+        /// <summary>
+        /// Updates the trees with the selection 
+        /// </summary>
+        /// <param name="selection">The collection of selected <see cref="ElementDefinitionRowViewModel"/> </param>
+        private void UpdateTreeBasedOnSelection(IEnumerable<ElementDefinitionRowViewModel> selection)
+        {
+        }
+
+        /// <summary>
+        /// Updates the tree
+        /// </summary>
+        /// <param name="shouldReset">A value indicating whether the tree should remove the element in preview</param>
+        public void UpdateTree(bool shouldReset)
+        {
+            if (shouldReset)
+            {
+                this.Reload();
+            }
+            else
+            {
+                this.ComputeValuesWrapper();
+            }
+        }
+
+        /// <summary>
+        /// Calls the <see cref="ComputeValues"/> with some household
+        /// </summary>
+        private void ComputeValuesWrapper()
+        {
+            this.IsBusy = true;
+            this.ComputeValues();
+            this.IsDirty = false;
+            this.IsBusy = false;
+        }
+
+        /// <summary>
+        /// Resets the variable tree
+        /// </summary>
+        private void Reload()
+        {
+            CDPMessageBus.Current.SendMessage(new DstHighlightEvent(this.RootElement.Name, false));
+        }
+        
+        /// <summary>
+        /// Computes the old values for each <see cref="P:DEHPCommon.UserInterfaces.ViewModels.ObjectBrowserViewModel.Things" />
+        /// </summary>
+        public void ComputeValues()
+        {
+            foreach (var mappedElement in this.DstController.HubMapResult)
+            {
+                this.UpdateElementRow(mappedElement);
+            }
+        }
+
+        /// <summary>
+        /// Updates the the corresponding variable according mapped by the <paramref name="mappedElement"/>
+        /// </summary>
+        /// <param name="mappedElement">The source <see cref="MappedElementDefinitionRowViewModel"/></param>
+        private void UpdateElementRow(MappedElementDefinitionRowViewModel mappedElement)
+        {
+            CDPMessageBus.Current.SendMessage(new DstHighlightEvent(mappedElement.SelectedCatiaElement.Name));
+        }
+
+        /// <summary>
+        /// Updates the <see cref="ProductTree"/> after a CATIA connection update.
+        /// </summary>
+        protected override void UpdateProductTree()
+        {
+            this.RootElement = null;
+            this.IsBusy = true;
+
+            this.WhenAny(x => x.DstController.ProductTree,
+                    x => x.Value)
+                .Where(x => x != null)
+                .Subscribe(p =>
+                {
+                    this.RootElement = p;
+                    this.IsBusy = false;
+                });
+        }
+
+        /// <summary>
+        /// Populate the context menu for this browser
+        /// </summary>
+        public override void PopulateContextMenu()
+        {
+            this.ContextMenu.Clear();
+        }
+    }
+}

--- a/DEHCATIA/ViewModels/NetChangePreview/HubNetChangePreviewViewModel.cs
+++ b/DEHCATIA/ViewModels/NetChangePreview/HubNetChangePreviewViewModel.cs
@@ -1,0 +1,444 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="HubNetChangePreviewViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.ViewModels.NetChangePreview
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reactive.Linq;
+
+    using CDP4Common.CommonData;
+    using CDP4Common.EngineeringModelData;
+
+    using CDP4Dal;
+    using CDP4Dal.Events;
+
+    using DEHCATIA.DstController;
+    using DEHCATIA.Events;
+    using DEHCATIA.ViewModels.Interfaces;
+    using DEHCATIA.ViewModels.ProductTree.Rows;
+
+    using DEHPCommon.Events;
+    using DEHPCommon.HubController.Interfaces;
+    using DEHPCommon.Services.ObjectBrowserTreeSelectorService;
+    using DEHPCommon.UserInterfaces.ViewModels;
+    using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
+    using DEHPCommon.UserInterfaces.ViewModels.NetChangePreview;
+    using DEHPCommon.UserInterfaces.ViewModels.Rows.ElementDefinitionTreeRows;
+
+    using ReactiveUI;
+
+    public class HubNetChangePreviewViewModel : NetChangePreviewViewModel, IHubNetChangePreviewViewModel
+    {
+        /// <summary>
+        /// The <see cref="IDstController"/>
+        /// </summary>
+        private readonly IDstController dstController;
+
+        /// <summary>
+        /// The collection of <see cref="ElementRowViewModel"/> that represents the latest selection
+        /// </summary>
+        private readonly List<ElementRowViewModel> previousSelection = new List<ElementRowViewModel>();
+
+        /// <summary>
+        /// Gets or sets a value indicating that the tree in the case that
+        /// <see cref="IDstController.DstMapResult"/> is not empty and the tree is not showing all changes
+        /// </summary>
+        public bool IsDirty { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:DEHPCommon.UserInterfaces.ViewModels.ObjectBrowserViewModel" /> class.
+        /// </summary>
+        /// <param name="hubController">The <see cref="T:DEHPCommon.HubController.Interfaces.IHubController" /></param>
+        /// <param name="objectBrowserTreeSelectorService">The <see cref="T:DEHPCommon.Services.ObjectBrowserTreeSelectorService.IObjectBrowserTreeSelectorService" /></param>
+        /// <param name="dstController">The <see cref="IDstController"/></param>
+        public HubNetChangePreviewViewModel(IHubController hubController, IObjectBrowserTreeSelectorService objectBrowserTreeSelectorService, IDstController dstController) : base(hubController, objectBrowserTreeSelectorService)
+        {
+            this.dstController = dstController;
+
+            CDPMessageBus.Current.Listen<UpdateHubPreviewBasedOnSelectionEvent>()
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(x => this.UpdateTreeBasedOnSelectionHandler(x.Selection.ToList()));
+
+            CDPMessageBus.Current.Listen<SessionEvent>(this.HubController.Session)
+                .Where(x => x.Status == SessionStatus.EndUpdate)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(x =>
+                {
+                    this.UpdateTreeBasedOnSelectionHandler(this.previousSelection);
+                });
+        }
+
+        /// <summary>
+        /// Updates the tree and filter changed things based on a selection
+        /// </summary>
+        /// <param name="selection">The collection of selected <see cref="ElementRowViewModel"/> </param>
+        private void UpdateTreeBasedOnSelectionHandler(IReadOnlyCollection<ElementRowViewModel> selection)
+        {
+            if (this.dstController.DstMapResult.Any())
+            {
+                this.IsBusy = true;
+
+                if (!selection.Any() && this.IsDirty)
+                {
+                    this.previousSelection.Clear();
+                    this.ComputeValuesWrapper();
+                }
+
+                else if (selection.Any())
+                {
+                    this.previousSelection.Clear();
+                    this.previousSelection.AddRange(selection);
+                    this.UpdateTreeBasedOnSelection(selection);
+                }
+
+                this.IsBusy = false;
+            }
+        }
+
+        /// <summary>
+        /// Updates the trees with the selection 
+        /// </summary>
+        /// <param name="selection">The collection of selected <see cref="ElementRowViewModel"/> </param>
+        private void UpdateTreeBasedOnSelection(IEnumerable<ElementRowViewModel> selection)
+        {
+            this.RestoreThings();
+            
+            foreach (var element in selection)
+            {
+                var parameters = (IEnumerable<ParameterOrOverrideBase>) element.ElementDefinition.Parameter;
+
+                if (element is UsageRowViewModel usageRow)
+                {
+                    parameters = usageRow.ElementUsage.ParameterOverride;
+                }
+
+                foreach (var parameterOrOverrideBase in parameters)
+                {
+                    var parameterRows = this.GetRows(parameterOrOverrideBase).ToList();
+
+                    if (!parameterRows.Any())
+                    {
+                        var oldElement = this.GetOldElement(parameterOrOverrideBase.Container);
+
+                        (oldElement as ElementDefinition)?.Parameter.RemoveAll(p =>
+                            parameters.Any(r => p.ParameterType.Iid == r.ParameterType.Iid));
+
+                        var elementRow = this.VerifyElementIsInTheTree(parameterOrOverrideBase);
+
+                        this.UpdateRow(parameterOrOverrideBase, (ElementDefinition)oldElement, elementRow);
+
+                        this.IsDirty = true;
+                    }
+
+                    foreach (var parameterRow in parameterRows)
+                    {
+                        var oldElement = this.GetOldElement(parameterRow.ContainerViewModel.Thing);
+
+                        if (parameterRow.ContainerViewModel is ElementDefinitionRowViewModel elementDefinitionRow)
+                        {
+                            this.UpdateRow(parameterOrOverrideBase, (ElementDefinition)oldElement, elementDefinitionRow);
+                        }
+
+                        else if (parameterRow.ContainerViewModel is ElementUsageRowViewModel elementUsageRow)
+                        {
+                            this.UpdateRow(parameterOrOverrideBase, (ElementUsage)oldElement, elementUsageRow);
+                        }
+
+                        this.IsDirty = true;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ElementBase"/> at the previous state that correspond to the <paramref name="container"/>
+        /// </summary>
+        /// <param name="container">The <see cref="Thing"/> container</param>
+        /// <returns>A <see cref="ElementBase"/></returns>
+        private ElementBase GetOldElement(Thing container)
+        {
+            return this.ThingsAtPreviousState
+                .FirstOrDefault(t => t.Iid == container.Iid
+                                  || container.Iid == Guid.Empty
+                                  && container is ElementDefinition element
+                                  && t is ElementDefinition previousStateElement
+                                  && element.Name == previousStateElement.Name
+                                  && element.ShortName == previousStateElement.ShortName)
+                as ElementBase;
+        }
+
+        /// <summary>
+        /// Updates the <paramref name="elementRow"/> children with the <paramref name="parameterOrOverrideBase"/>
+        /// </summary>
+        /// <typeparam name="TThing">The precise type of <see cref="ElementBase"/></typeparam>
+        /// <typeparam name="TRow">The type of <paramref name="elementRow"/></typeparam>
+        /// <param name="parameterOrOverrideBase">The <see cref="ParameterOrOverrideBase"/></param>
+        /// <param name="oldElement">The old <see cref="ElementBase"/> to be updated</param>
+        /// <param name="elementRow">The row to perform on the update</param>
+        private void UpdateRow<TThing, TRow>(ParameterOrOverrideBase parameterOrOverrideBase, TThing oldElement, TRow elementRow) 
+            where TRow : ElementBaseRowViewModel<TThing> where TThing : ElementBase
+        {
+            var updatedElement = (TThing)oldElement?.Clone(true);
+
+            this.AddOrReplaceParameter(updatedElement, parameterOrOverrideBase);
+
+            CDPMessageBus.Current.SendMessage(new HighlightEvent(elementRow.Thing), elementRow.Thing);
+
+            elementRow.UpdateThing(updatedElement);
+
+            elementRow.UpdateChildren();
+        }
+
+        /// <summary>
+        /// Restores the tree to the point before <see cref="ComputeValues"/> was executed the first time
+        /// </summary>
+        private void RestoreThings()
+        {
+            var isExpanded = this.Things.First().IsExpanded;
+            this.UpdateTree(true);
+            this.Things.First().IsExpanded = isExpanded;
+        }
+
+        /// <summary>
+        /// Adds or replace the <paramref name="parameterOrOverride"/> on the <paramref name="updatedElement"/>
+        /// </summary>
+        /// <param name="updatedElement">The <see cref="ElementBase"/></param>
+        /// <param name="parameterOrOverride">The <see cref="ParameterOrOverrideBase"/></param>
+        private void AddOrReplaceParameter(ElementBase updatedElement, ParameterOrOverrideBase parameterOrOverride)
+        {
+            if (updatedElement is ElementDefinition elementDefinition)
+            {
+                if (elementDefinition.Parameter.FirstOrDefault(p => p.ParameterType.Iid == parameterOrOverride.ParameterType.Iid)
+                    is { } parameter)
+                {
+                    elementDefinition.Parameter.Remove(parameter);
+                }
+
+                elementDefinition.Parameter.Add((Parameter)parameterOrOverride);
+            }
+
+            else if (updatedElement is ElementUsage elementUsage)
+            {
+                if (parameterOrOverride is Parameter elementParameter)
+                {
+                    if (elementUsage.ElementDefinition.Parameter.FirstOrDefault(p => p.ParameterType.Iid == parameterOrOverride.ParameterType.Iid)
+                        is { } parameter)
+                    {
+                        elementUsage.ElementDefinition.Parameter.Remove(parameter);
+                    }
+
+                    elementUsage.ElementDefinition.Parameter.Add(elementParameter);
+                }
+
+                else if (parameterOrOverride is ParameterOverride parameterOverride)
+                {
+                    if (elementUsage.ParameterOverride.FirstOrDefault(p => p.ParameterType.Iid == parameterOrOverride.ParameterType.Iid)
+                        is { } parameter)
+                    {
+                        elementUsage.ParameterOverride.Remove(parameter);
+                    }
+
+                    elementUsage.ParameterOverride.Add(parameterOverride);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets all the rows of type <see cref="ParameterOrOverrideBase}"/> that are related to <paramref name="parameter"/>
+        /// </summary>
+        /// <param name="parameter">The <see cref="ParameterBase"/></param>
+        /// <returns>A collection of <see cref="IRowViewModelBase{T}"/> of type <see cref="ParameterOrOverrideBase"/></returns>
+        private IEnumerable<IRowViewModelBase<ParameterOrOverrideBase>> GetRows(ParameterBase parameter)
+        {
+            var result = new List<IRowViewModelBase<ParameterOrOverrideBase>>();
+
+            foreach (var elementDefinitionRow in this.Things.OfType<ElementDefinitionsBrowserViewModel>()
+                .SelectMany(x => x.ContainedRows.OfType<ElementDefinitionRowViewModel>()))
+            {
+                result.AddRange(elementDefinitionRow.ContainedRows.OfType<ElementUsageRowViewModel>()
+                    .SelectMany(x => x.ContainedRows
+                        .OfType<IRowViewModelBase<ParameterOrOverrideBase>>())
+                    .Where(parameterRow => VerifyRowContainsTheParameter(parameter, parameterRow)));
+
+                result.AddRange(elementDefinitionRow.ContainedRows
+                    .OfType<IRowViewModelBase<ParameterOrOverrideBase>>()
+                    .Where(parameterRow => VerifyRowContainsTheParameter(parameter, parameterRow)));
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Verify that the <paramref name="parameterRow"/> contains the <paramref name="parameter"/>
+        /// </summary>
+        /// <param name="parameter">The <see cref="ParameterBase"/></param>
+        /// <param name="parameterRow">The <see cref="IRowViewModelBase{T}"/></param>
+        /// <returns>An assert</returns>
+        private static bool VerifyRowContainsTheParameter(ParameterBase parameter, IRowViewModelBase<ParameterOrOverrideBase> parameterRow)
+        {
+            var containerIsTheRightOne = (parameterRow.ContainerViewModel.Thing.Iid == parameter.Container.Iid ||
+                                          (parameterRow.ContainerViewModel.Thing is ElementUsage elementUsage
+                                           && (elementUsage.ElementDefinition.Iid == parameter.Container.Iid
+                                           || elementUsage.Iid == parameter.Container.Iid)));
+
+            var parameterIsTheRightOne = (parameterRow.Thing.Iid == parameter.Iid ||
+                                          (parameter.Iid == Guid.Empty
+                                           && parameter.ParameterType.Iid == parameterRow.Thing.ParameterType.Iid));
+
+            return containerIsTheRightOne && parameterIsTheRightOne;
+        }
+
+        /// <summary>
+        /// Updates the tree
+        /// </summary>
+        /// <param name="shouldReset">A value indicating whether the tree should remove the element in preview</param>
+        public override void UpdateTree(bool shouldReset)
+        {
+            if (shouldReset)
+            {
+                this.Reload();
+            }
+            else
+            {
+                this.ComputeValuesWrapper();
+            }
+        }
+
+        /// <summary>
+        /// Calls the <see cref="ComputeValues"/> with some household
+        /// </summary>
+        private void ComputeValuesWrapper()
+        {
+            this.IsBusy = true;
+            this.ThingsAtPreviousState.Clear();
+            var isExpanded = this.Things.First().IsExpanded;
+            this.ComputeValues();
+            this.Things.First().IsExpanded = isExpanded;
+            this.IsDirty = false;
+            this.IsBusy = false;
+        }
+
+        /// <summary>
+        /// Computes the old values for each <see cref="P:DEHPCommon.UserInterfaces.ViewModels.ObjectBrowserViewModel.Things" />
+        /// </summary>
+        public override void ComputeValues()
+        {
+            foreach (var parameterOverride in this.dstController.DstMapResult.Select(x => x.Element).OfType<ElementUsage>()
+                .SelectMany(x => x.ParameterOverride))
+            {
+                var parameterRows = this.GetRows(parameterOverride).ToList();
+
+                foreach (var parameterRow in parameterRows)
+                {
+                    if (parameterRow.ContainerViewModel is ElementUsageRowViewModel elementUsageRow)
+                    {
+                        this.UpdateRow(parameterOverride, elementUsageRow.Thing, elementUsageRow);
+                    }
+
+                    this.ThingsAtPreviousState.Add(parameterRow.ContainerViewModel.Thing.Clone(true));
+                }
+            }
+
+            foreach (var parameter in this.dstController.DstMapResult.Select(x => x.Element).OfType<ElementDefinition>()
+                .SelectMany(x => x.Parameter))
+            {
+                var elementRow = this.VerifyElementIsInTheTree(parameter);
+
+                if (parameter.Iid == Guid.Empty)
+                {
+                    this.UpdateRow(parameter, (ElementDefinition)parameter.Container, elementRow);
+                    this.AddToThingsAtPreviousState(elementRow.Thing);
+                    continue;
+                }
+
+                var parameterRows = this.GetRows(parameter).ToList();
+                
+                foreach (var parameterRow in parameterRows)
+                {
+                    if (parameterRow.ContainerViewModel is ElementDefinitionRowViewModel elementDefinitionRow)
+                    {
+                        this.UpdateRow(parameter, elementDefinitionRow.Thing, elementDefinitionRow);
+                    }
+
+                    else if (parameterRow.ContainerViewModel is ElementUsageRowViewModel elementUsageRow)
+                    {
+                        this.UpdateRow(parameter, elementUsageRow.Thing, elementUsageRow);
+                    }
+
+                    this.AddToThingsAtPreviousState(parameterRow.ContainerViewModel.Thing);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Adds to <see cref="NetChangePreviewViewModel.ThingsAtPreviousState"/>
+        /// </summary>
+        /// <param name="element">The element to add</param>
+        private void AddToThingsAtPreviousState(Thing element)
+        {
+            var existing = this.GetOldElement(element);
+
+            if (existing == null)
+            {
+                this.ThingsAtPreviousState.Add(element.Clone(true));
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the <see cref="ElementDefinition"/> container of the <paramref name="parameterOrOverrideBase"/>
+        /// exists in the tree. If not it creates it
+        /// </summary>
+        /// <param name="parameterOrOverrideBase">The <see cref="Thing"/> parameterOrOverrideBase</param>
+        /// <returns>A <see cref="ElementDefinitionRowViewModel"/></returns>
+        private ElementDefinitionRowViewModel VerifyElementIsInTheTree(Thing parameterOrOverrideBase)
+        {
+            var iterationRow =
+                this.Things.OfType<ElementDefinitionsBrowserViewModel>().FirstOrDefault();
+
+            var elementDefinitionRow = iterationRow.ContainedRows.OfType<ElementDefinitionRowViewModel>()
+                .FirstOrDefault(e => e.Thing.Iid == parameterOrOverrideBase.Container.Iid
+                                     && e.Thing.Name == ((INamedThing) parameterOrOverrideBase.Container).Name);
+
+            if (elementDefinitionRow is null)
+            {
+                elementDefinitionRow = new ElementDefinitionRowViewModel((ElementDefinition) parameterOrOverrideBase.Container,
+                    this.HubController.CurrentDomainOfExpertise, this.HubController.Session, iterationRow);
+
+                iterationRow.ContainedRows.Add(elementDefinitionRow);
+            }
+
+            return elementDefinitionRow;
+        }
+
+        /// <summary>
+        /// Not available for the net change preview panel
+        /// </summary>
+        public override void PopulateContextMenu()
+        {
+            this.ContextMenu.Clear();
+        }
+    }
+}

--- a/DEHCATIA/ViewModels/NetChangePreview/HubNetChangePreviewViewModel.cs
+++ b/DEHCATIA/ViewModels/NetChangePreview/HubNetChangePreviewViewModel.cs
@@ -402,7 +402,7 @@ namespace DEHCATIA.ViewModels.NetChangePreview
             var existing = this.GetOldElement(element);
 
             if (existing == null)
-            {
+            {   
                 this.ThingsAtPreviousState.Add(element.Clone(true));
             }
         }

--- a/DEHCATIA/ViewModels/ProductTree/Rows/DefinitionRowViewModel.cs
+++ b/DEHCATIA/ViewModels/ProductTree/Rows/DefinitionRowViewModel.cs
@@ -27,7 +27,6 @@ namespace DEHCATIA.ViewModels.ProductTree.Rows
     using CDP4Common.EngineeringModelData;
 
     using DEHCATIA.Enumerations;
-    using DEHCATIA.ViewModels.ProductTree.Shapes;
 
     using ProductStructureTypeLib;
 

--- a/DEHCATIA/ViewModels/ProductTree/Rows/ElementRowViewModel.cs
+++ b/DEHCATIA/ViewModels/ProductTree/Rows/ElementRowViewModel.cs
@@ -24,11 +24,19 @@
 
 namespace DEHCATIA.ViewModels.ProductTree.Rows
 {
+    using System;
+    using System.Reactive.Linq;
+
     using CDP4Common.EngineeringModelData;
 
+    using CDP4Dal;
+
     using DEHCATIA.Enumerations;
+    using DEHCATIA.Events;
     using DEHCATIA.ViewModels.ProductTree.Parameters;
     using DEHCATIA.ViewModels.ProductTree.Shapes;
+
+    using DEHPCommon.Events;
 
     using ProductStructureTypeLib;
 
@@ -72,7 +80,7 @@ namespace DEHCATIA.ViewModels.ProductTree.Rows
         /// <summary>
         /// Backing field for <see cref="IsHighlighted"/>
         /// </summary>
-        private string isHighlighted;
+        private bool isHighlighted;
 
         /// <summary>
         /// Backing field for <see cref="Shape"/>
@@ -118,7 +126,7 @@ namespace DEHCATIA.ViewModels.ProductTree.Rows
         /// Backing field for <see cref="Parent"/>
         /// </summary>
         private ElementRowViewModel parent;
-
+        
         /// <summary>
         /// Gets or sets the element name.
         /// </summary>
@@ -165,9 +173,9 @@ namespace DEHCATIA.ViewModels.ProductTree.Rows
         }
 
         /// <summary>
-        /// Gets or sets a value whether the row is highlighted
+        /// Gets or sets a value indicating whether the row is highlighted
         /// </summary>
-        public string IsHighlighted
+        public bool IsHighlighted
         {
             get => this.isHighlighted;
             set => this.RaiseAndSetIfChanged(ref this.isHighlighted, value);
@@ -284,6 +292,11 @@ namespace DEHCATIA.ViewModels.ProductTree.Rows
             this.PartNumber = product.get_PartNumber();
             this.Description = product.get_DescriptionRef();
             this.FileName = fileName;
+
+            CDPMessageBus.Current.Listen<DstHighlightEvent>()
+                .Where(x => (string) x.TargetThingId == this.Name)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(x => this.IsHighlighted = x.ShouldHighlight);
         }
     }
 }

--- a/DEHCATIA/ViewModels/Rows/MappedElementDefinitionRowViewModel.cs
+++ b/DEHCATIA/ViewModels/Rows/MappedElementDefinitionRowViewModel.cs
@@ -1,0 +1,106 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="MappedElementDefinitionRowViewModel.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.ViewModels.Rows
+{
+    using System;
+
+    using CDP4Common.EngineeringModelData;
+
+    using DEHCATIA.ViewModels.ProductTree.Rows;
+
+    using ReactiveUI;
+
+    /// <summary>
+    /// Represents a collection of <see cref="ParameterOrOverrideBase"/> from the Hub source and a <see cref="SelectedElement"/> to update
+    /// </summary>
+    public class MappedElementDefinitionRowViewModel : ReactiveObject
+    {
+        /// <summary>
+        /// Backing field for <see cref="SelectedElement"/>
+        /// </summary>
+        private ElementBase selectedElement;
+
+        /// <summary>
+        /// Gets or sets the <see cref="ElementRowViewModel"/> holding the destination <see cref="Opc.Ua.ReferenceDescription"/>
+        /// </summary>
+        public ElementBase SelectedElement
+        {
+            get => this.selectedElement;
+            set => this.RaiseAndSetIfChanged(ref this.selectedElement, value);
+        }
+        
+        /// <summary>
+        /// Backing field for <see cref="SelectedElement"/>
+        /// </summary>
+        private ElementRowViewModel selectedCatiaElement;
+
+        /// <summary>
+        /// Gets or sets the <see cref="ElementRowViewModel"/> holding the destination <see cref="Opc.Ua.ReferenceDescription"/>
+        /// </summary>
+        public ElementRowViewModel SelectedCatiaElement
+        {
+            get => this.selectedCatiaElement;
+            set => this.RaiseAndSetIfChanged(ref this.selectedCatiaElement, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the selected <see cref="Parameter"/>s
+        /// </summary>
+        public ReactiveList<ParameterOrOverrideBase> SelectedParameters { get; } = new ReactiveList<ParameterOrOverrideBase>();
+        
+        /// <summary>
+        /// Backing field fopr <see cref="IsValid"/>
+        /// </summary>
+        private bool isValid;
+
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="MappedElementDefinitionRowViewModel"/> is ready to be mapped
+        /// </summary>
+        public bool IsValid
+        {
+            get => this.isValid;
+            set => this.RaiseAndSetIfChanged(ref this.isValid, value);
+        }
+
+        /// <summary>
+        /// Initializes a new <see cref="MappedElementDefinitionRowViewModel"/>
+        /// </summary>
+        public MappedElementDefinitionRowViewModel()
+        {
+            this.WhenAnyValue(x => x.SelectedElement)
+                .Subscribe(_ => this.VerifyValidity());
+
+            this.SelectedParameters.CountChanged.Subscribe(_ => this.VerifyValidity());
+        }
+
+        /// <summary>
+        /// Verify validity of the this <see cref="MappedElementDefinitionRowViewModel"/>
+        /// </summary>
+        public void VerifyValidity()
+        {
+            this.IsValid = this.SelectedParameters.Count > 0 && this.SelectedElement != null;
+        }
+    }
+}

--- a/DEHCATIA/Views/Dialogs/DstLogin.xaml
+++ b/DEHCATIA/Views/Dialogs/DstLogin.xaml
@@ -1,0 +1,95 @@
+﻿<dx:DXDialogWindow x:Class="DEHCATIA.Views.Dialogs.DstLogin" 
+                   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
+                   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                   xmlns:dx="http://schemas.devexpress.com/winfx/2008/xaml/core" 
+                   xmlns:dxe="http://schemas.devexpress.com/winfx/2008/xaml/editors"
+                   xmlns:dxlc="http://schemas.devexpress.com/winfx/2008/xaml/layoutcontrol" 
+                   xmlns:dxmvvm="http://schemas.devexpress.com/winfx/2008/xaml/mvvm"
+                   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                   xmlns:behaviors="clr-namespace:DEHPCommon.UserInterfaces.Behaviors;assembly=DEHPCommon"
+                   xmlns:system="clr-namespace:System;assembly=mscorlib"
+                   Title="Connections"
+                   mc:Ignorable="d" Height="300" d:DesignWidth="409" MinWidth="600"  Width="400" Topmost="True">
+    <dxmvvm:Interaction.Behaviors>
+        <behaviors:CloseWindowBehavior/>
+    </dxmvvm:Interaction.Behaviors>
+    <Window.Resources>
+        <ResourceDictionary>
+            <Style x:Key="IsReadOnlyStyle" TargetType="{x:Type Control}">
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding LoginSuccessful}" Value="True">
+                        <Setter Property="IsEnabled" Value="False" />
+                    </DataTrigger>
+                    <DataTrigger Binding="{Binding LoginSuccessful}" Value="False">
+                        <Setter Property="IsEnabled" Value="True" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </ResourceDictionary>
+    </Window.Resources>
+    <dx:LoadingDecorator BorderEffect="Default" BorderEffectColor="Blue" IsSplashScreenShown="{Binding IsBusy}" OwnerLock="LoadingContent">
+        <Grid Margin="10">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Label VerticalAlignment="Center" MaxWidth="400" Grid.Row="0" Grid.Column="0" Content="Pick a mapping configuration" HorizontalAlignment="Left" FontSize="18" />
+
+            <Grid Grid.Row="1" VerticalAlignment="Center">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="220" />
+                    <ColumnDefinition />
+                    <ColumnDefinition Width="50" />
+                </Grid.ColumnDefinitions>
+
+                <!--  Mapping  -->
+                <dxlc:LayoutItemLabel Grid.Column="0" VerticalAlignment="Center" Height="Auto" Margin="5" Content="Mapping Configuration" FontSize="12"/>
+                <Grid Grid.Column="1" Grid.ColumnSpan="2">
+                    <Grid.RowDefinitions>
+                        <RowDefinition></RowDefinition>
+                        <RowDefinition></RowDefinition>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"></ColumnDefinition>
+                        <ColumnDefinition></ColumnDefinition>
+                    </Grid.ColumnDefinitions>
+                    <CheckBox Grid.Column="0" Grid.Row="1" Margin="5" Style="{StaticResource IsReadOnlyStyle}" Content="New Configuration" IsChecked="{Binding CreateNewMappingConfigurationChecked}"></CheckBox>
+                    <dxe:ComboBoxEdit Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Style="{StaticResource IsReadOnlyStyle}" Name="ModelBoxEdit"  DisplayMember="ExternalModelName" ShowNullTextForEmptyValue="True"
+                                      Height="Auto" Margin="5" FontSize="12" SelectedItem="{Binding SelectedExternalIdentifierMap}"
+                                      ItemsSource="{Binding AvailableExternalIdentifierMap}" IncrementalFiltering="True" NullValueButtonPlacement="EditBox" NullText="No Mapping Configuration Selected"
+                                      ToolTip="Select an existing mapping"/>
+
+                    <dxe:TextEdit Grid.Column="1" Style="{StaticResource IsReadOnlyStyle}" Grid.Row="1" Height="Auto" Margin="5" FontSize="12" ShowNullTextForEmptyValue="True"
+                                  ToolTip="Enter a name wich will identify the mapping configuration to be saved  &#x0a;suggestion: EcosimPro Model / Experiment Name" NullText="Enter a new mapping configuration name"
+                                  Text="{Binding Path=ExternalIdentifierMapNewName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+                </Grid>
+
+            </Grid>
+
+            <Grid Grid.Row="2">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition></ColumnDefinition>
+                    <ColumnDefinition Width="Auto"></ColumnDefinition>
+                    <ColumnDefinition Width="Auto"></ColumnDefinition>
+                    <ColumnDefinition Width="Auto"></ColumnDefinition>
+                    <ColumnDefinition Width="Auto"></ColumnDefinition>
+                </Grid.ColumnDefinitions>
+                <Image Grid.Column="1" Height="24" Width="24" HorizontalAlignment="Right" Source="{dx:DXImage Image=Apply_32x32.png}" Visibility="{Binding Path=LoginSuccessful, Converter={dxmvvm:BooleanToVisibilityConverter}, UpdateSourceTrigger=PropertyChanged}" />
+
+                <Button ToolTip="Cancel connection to Catia" IsCancel="True" Grid.Column="2" Height="Auto" 
+                        MinWidth="100" Margin="5" HorizontalAlignment="Right" Command="{Binding CancelCommand}" Width="117">Cancel</Button>
+                <Button ToolTip="Connect to the running Catia instance" IsDefault="True" Grid.Column="3" Height="Auto" 
+                        MinWidth="100" Margin="5" HorizontalAlignment="Right" Command="{Binding ConnectCommand}" Width="117"
+                        Visibility="{Binding Path=LoginSuccessful, Converter={dxmvvm:BooleanToVisibilityConverter Inverse=True}, UpdateSourceTrigger=PropertyChanged}">
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Margin="0,0,10,0" VerticalAlignment="Center" Text="Connect" />
+                        <Image Height="24" Width="24" Source="{dx:DXImage Image=Right_32x32.png}" Stretch="Uniform" />
+                    </StackPanel>
+                </Button>
+            </Grid>
+        </Grid>
+    </dx:LoadingDecorator>
+</dx:DXDialogWindow>

--- a/DEHCATIA/Views/Dialogs/DstLogin.xaml.cs
+++ b/DEHCATIA/Views/Dialogs/DstLogin.xaml.cs
@@ -1,0 +1,42 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="DstLogin.xaml.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2020 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHCATIA
+// 
+//    The DEHCATIA is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHCATIA is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.Views.Dialogs
+{
+    using DevExpress.Xpf.Core;
+
+    /// <summary>
+    /// Interaction logic for DstLogin.xaml
+    /// </summary>
+    public partial class DstLogin : DXDialogWindow
+    {
+        /// <summary>
+        /// Initializes a new <see cref="DstLogin"/>
+        /// </summary>
+        public DstLogin()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/DEHCATIA/Views/Dialogs/DstMappingConfigurationDialog.xaml
+++ b/DEHCATIA/Views/Dialogs/DstMappingConfigurationDialog.xaml
@@ -245,6 +245,7 @@
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
                             <RowDefinition Height="Auto"/>
+                            <RowDefinition Height="Auto"/>
                             <RowDefinition Height="*"/>
                         </Grid.RowDefinitions>
 
@@ -252,10 +253,9 @@
                         <dxe:ComboBoxEdit Grid.Row="1" Grid.Column="1" Margin="2" AllowNullInput="True" AutoComplete="True" ClearSelectionOnBackspace="True" 
                                           DisplayMember="ShortName" ItemsSource="{Binding AvailableElementDefinitions}"
                                           NullText="Create New Element Definition" NullValueButtonPlacement="EditBox"
-                                          SelectedItem="{Binding SelectedThing.ElementDefinition}"
+                                          SelectedItem="{Binding SelectedThing.ElementDefinition, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                                           ToolTip="Select an ElementDefinition to be mapped with the top element of the selected tree"
-                                          ShowNullTextForEmptyValue="True" ValidateOnTextInput="False" ValueMember="Name" 
-                                          IsEnabled="{Binding AreHubFieldsEditable}">
+                                          ShowNullTextForEmptyValue="True" ValidateOnTextInput="False" ValueMember="Name">
                             <dxe:ComboBoxEdit.ItemTemplate>
                                 <DataTemplate>
                                     <TextBlock>
@@ -269,20 +269,39 @@
                                 </DataTemplate>
                             </dxe:ComboBoxEdit.ItemTemplate>
                         </dxe:ComboBoxEdit>
-                        <Label Grid.Row="2" Grid.Column="0" Content="Actual Finite State:" />
-                        <dxe:ComboBoxEdit Grid.Row="2" Grid.Column="1" Margin="2" ApplyItemTemplateToSelectedItem="True" AutoComplete="True" DisplayMember="Name"
+                        <Label Grid.Row="2" Grid.Column="0" Content="Element Usage:" />
+                        <dxe:ComboBoxEdit Grid.Row="2" Grid.Column="1" Margin="2" AllowNullInput="True" AutoComplete="True" ClearSelectionOnBackspace="True" 
+                                          DisplayMember="ShortName" ItemsSource="{Binding AvailableElementUsages}"
+                                          NullText="Create New Element Usage" NullValueButtonPlacement="EditBox" IsEnabled="{Binding CanSetAnElementUsage}"
+                                          SelectedItem="{Binding SelectedThing.ElementUsage, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
+                                          ToolTip="Select an ElementUsage to be mapped with the current element of the selected tree"
+                                          ShowNullTextForEmptyValue="True" ValidateOnTextInput="False" ValueMember="Name">
+                            <dxe:ComboBoxEdit.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock>
+                                        <TextBlock.Text>
+                                            <MultiBinding StringFormat="{}{0} [{1}]">
+                                                <Binding Path="Name" />
+                                                <Binding Path="ShortName" />
+                                            </MultiBinding>
+                                        </TextBlock.Text>
+                                    </TextBlock>
+                                </DataTemplate>
+                            </dxe:ComboBoxEdit.ItemTemplate>
+                        </dxe:ComboBoxEdit>
+                        <Label Grid.Row="3" Grid.Column="0" Content="Actual Finite State:" />
+                        <dxe:ComboBoxEdit Grid.Row="3" Grid.Column="1" Margin="2" ApplyItemTemplateToSelectedItem="True" AutoComplete="True" DisplayMember="Name"
                                           ItemsSource="{Binding AvailableActualFiniteStates}"
-                                          NullText="No State Depent Parameter Selected"
-                                          SelectedItem="{Binding SelectedThing.SelectedActualFiniteState}"
+                                          NullText="No ActualFiniteState Selected"
+                                          SelectedItem="{Binding SelectedThing.SelectedActualFiniteState, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                                           ToolTip="Select a ActualFiniteState if the destination contains any state dependant parameters,&#x0a;these parameters with the corresponding state valuesets will be updated"
-                                          ShowNullTextForEmptyValue="True" ValidateOnTextInput="False" ValueMember="Name" 
-                                          IsEnabled="{Binding AreHubFieldsEditable}"/>
-                        <Label Grid.Row="3" Grid.Column="0" Content="Option:" />
-                        <dxe:ComboBoxEdit Grid.Row="3" Grid.Column="1" Margin="2" AutoComplete="True" DisplayMember="ShortName"
+                                          ShowNullTextForEmptyValue="True" ValidateOnTextInput="False" ValueMember="Name"/>
+                        <Label Grid.Row="4" Grid.Column="0" Content="Option:" />
+                        <dxe:ComboBoxEdit Grid.Row="4" Grid.Column="1" Margin="2" AutoComplete="True" DisplayMember="ShortName"
                                           ItemsSource="{Binding AvailableOptions}" SelectedIndex="0" NullText="Select an option"
-                                          SelectedItem="{Binding SelectedThing.SelectedOption}" NullValueButtonPlacement="EditBox"
-                                          ShowNullTextForEmptyValue="True" ValidateOnTextInput="False" 
-                                          ValueMember="Name" AllowNullInput="True" IsEnabled="{Binding AreHubFieldsEditable}"
+                                          SelectedItem="{Binding SelectedThing.SelectedOption, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" 
+                                          NullValueButtonPlacement="EditBox" ShowNullTextForEmptyValue="True" ValidateOnTextInput="False" 
+                                          ValueMember="Name" AllowNullInput="True"
                                           ToolTip="Select an Option, if the destination contains any option dependant parameters,&#x0a;these parameters with the corresponding option valuesets will be updated"/>
                     </Grid>
                 </Grid>

--- a/DEHCATIA/Views/MainWindow.xaml
+++ b/DEHCATIA/Views/MainWindow.xaml
@@ -94,15 +94,11 @@
                                 </Grid.RowDefinitions>
 
                                 <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
-                                    <Button Margin="0,0,10,0" Width="150" Height="40" HorizontalAlignment="Right" 
-                                            Content="{Binding HubDataSourceViewModel.ConnectButtonText}" Command="{Binding HubDataSourceViewModel.ConnectCommand}"
-                                            ToolTip="Connect or disconnect from a Hub data source"/>
-
-                                    <Button Width="40" Height="40" HorizontalAlignment="Left"
-                                            Command="{Binding HubDataSourceViewModel.RefreshCommand}"
-                                            ToolTip="Refresh the session">
-                                        <Image Source="{dx:DXImage 'Images/Actions/Refresh2_32x32.png'}"></Image>
-                                    </Button>
+                                    <Button Width="150" Height="40" HorizontalAlignment="Right" 
+                                            Command="{Binding HubDataSourceViewModel.ConnectCommand}" 
+                                            Content="{Binding HubDataSourceViewModel.ConnectButtonText}" 
+                                            ToolTip="Connect or disconnect from a Hub data source" />
+                                    <common:HubSessionControl DataContext="{Binding HubDataSourceViewModel.SessionControl}"></common:HubSessionControl>
                                 </StackPanel>
                                 <Grid Grid.Row="1" Background="AliceBlue">
                                     <Grid.RowDefinitions>

--- a/DEHCATIA/Views/MainWindow.xaml
+++ b/DEHCATIA/Views/MainWindow.xaml
@@ -41,7 +41,12 @@
                                     <RowDefinition Height="Auto"></RowDefinition>
                                     <RowDefinition></RowDefinition>
                                 </Grid.RowDefinitions>
-                                <Button Width="150" Height="40" HorizontalAlignment="Center" Content="{Binding DstSourceViewModel.ConnectButtonText}" Command="{Binding DstSourceViewModel.ConnectCommand}"/>
+                                <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
+                                    <Button Width="150" Height="40" HorizontalAlignment="Center" Content="{Binding DstSourceViewModel.ConnectButtonText}" Command="{Binding DstSourceViewModel.ConnectCommand}"/>
+                                    <Button Width="40" Height="40" Margin="10,0,10,0" Padding="8" HorizontalAlignment="Left" Command="{Binding DstSourceViewModel.RefreshCommand}" ToolTip="Refresh the connection with Catia and the product tree">
+                                        <Image Source="{dx:DXImage 'Images/Actions/Refresh2_32x32.png'}" />
+                                    </Button>
+                                </StackPanel>
                                 <Grid Grid.Row="1">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEH-CATIA/pulls) open
- [x] I have verified that I am following the DEH-CATIA [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEH-CATIA/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
fixes #32 
<!-- A description of the changes proposed in the pull-request -->
- [x] Added the different Impact view
- [x] Loading of the dst mapping at dst connection time
- [ ] Loading of the hub mapping not done (missing the mapping configuration from HubToDst)
- [ ] preview based on selection (only from dst to hub) (untested) only via unitest
- [ ] Added saving the mapping (only from dst to hub) with support for only one top element per ExternalIdentifierMap  (untested) only via unitest
- [x] Remapping
- [x] Mapping is always ready
- [x] Added a dst refresh
- [x] Mapping is done on shortname
<!-- Thanks for contributing to DEH-CATIA! -->