### PR TITLE
Mapping rules; fixes #37

### DIFF
--- a/DEHCATIA.Tests/Converters/ElementTypeToIconConverterTestFixture.cs
+++ b/DEHCATIA.Tests/Converters/ElementTypeToIconConverterTestFixture.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHCATIA.Tests/DstController/DstControllerTestFixture.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA.Tests/Extensions/CatiaParameterExtensionTestFixture.cs
+++ b/DEHCATIA.Tests/Extensions/CatiaParameterExtensionTestFixture.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA.Tests/MappingRules/CatiaProductToElementRuleTestFixture.cs
+++ b/DEHCATIA.Tests/MappingRules/CatiaProductToElementRuleTestFixture.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA.Tests/MappingRules/ElementToCatiaRuleTestFixture.cs
+++ b/DEHCATIA.Tests/MappingRules/ElementToCatiaRuleTestFixture.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.
@@ -168,28 +168,28 @@ namespace DEHCATIA.Tests.MappingRules
             var mappedElementRowViewModel = new MappedElementRowViewModel() { CatiaElement = new ElementRowViewModel(new Mock<ProductStructureTypeLib.Product>().Object, "") };
 
             IEnumerable<bool> boolResult = new List<bool>();
-            Assert.DoesNotThrow(() => boolResult = this.rule.GetParameterValue<bool>(this.elementDefinition.Parameter, this.booleanParameterType.Iid, mappedElementRowViewModel));
+            Assert.DoesNotThrow(() => boolResult = this.rule.GetParameterValues<bool>(this.elementDefinition.Parameter, this.booleanParameterType.Iid, mappedElementRowViewModel));
             Assert.AreEqual(1, boolResult.Count());
             Assert.IsTrue(boolResult.FirstOrDefault());
 
             IEnumerable<double> doubleResult = new List<double>();
-            Assert.DoesNotThrow(() => doubleResult = this.rule.GetParameterValue<double>(this.elementDefinition.Parameter, this.quantityParameterType.Iid, mappedElementRowViewModel));
+            Assert.DoesNotThrow(() => doubleResult = this.rule.GetParameterValues<double>(this.elementDefinition.Parameter, this.quantityParameterType.Iid, mappedElementRowViewModel));
             Assert.AreEqual(2, doubleResult.Count());
             Assert.AreEqual(.42, doubleResult.Last());
 
             IEnumerable<string> stringResult = new List<string>();
-            Assert.DoesNotThrow(() => stringResult = this.rule.GetParameterValue<string>(this.elementDefinition.Parameter, this.textParameterType.Iid, mappedElementRowViewModel));
+            Assert.DoesNotThrow(() => stringResult = this.rule.GetParameterValues<string>(this.elementDefinition.Parameter, this.textParameterType.Iid, mappedElementRowViewModel));
             Assert.AreEqual(1, stringResult.Count());
             Assert.AreEqual("text", stringResult.FirstOrDefault());
 
             IEnumerable<ShapeKind> enumResult = new List<ShapeKind>();
-            Assert.DoesNotThrow(() => enumResult = this.rule.GetParameterEnumValue<ShapeKind>(this.elementDefinition.Parameter, this.enumerationParameterType.Iid, mappedElementRowViewModel));
+            Assert.DoesNotThrow(() => enumResult = this.rule.GetParameterEnumValues<ShapeKind>(this.elementDefinition.Parameter, this.enumerationParameterType.Iid, mappedElementRowViewModel));
             Assert.AreEqual(1, enumResult.Count());
             Assert.AreEqual(ShapeKind.Box, enumResult.FirstOrDefault());
 
             Assert.IsEmpty(this.rule.MappingErrors);
             IEnumerable<double> badResult = new List<double>();
-            Assert.DoesNotThrow(() => badResult = this.rule.GetParameterValue<double>(this.elementDefinition.Parameter, this.textParameterType.Iid, mappedElementRowViewModel));
+            Assert.DoesNotThrow(() => badResult = this.rule.GetParameterValues<double>(this.elementDefinition.Parameter, this.textParameterType.Iid, mappedElementRowViewModel));
             Assert.AreEqual(0, badResult.Count());
             Assert.IsNotEmpty(this.rule.MappingErrors);
         }

--- a/DEHCATIA.Tests/MappingRules/ElementToCatiaRuleTestFixture.cs
+++ b/DEHCATIA.Tests/MappingRules/ElementToCatiaRuleTestFixture.cs
@@ -1,0 +1,224 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ElementToCatiaRuleTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.Tests.MappingRules
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+
+    using Autofac;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using DEHCATIA.DstController;
+    using DEHCATIA.Enumerations;
+    using DEHCATIA.MappingRules;
+    using DEHCATIA.Services.CatiaTemplateService;
+    using DEHCATIA.Services.ParameterTypeService;
+    using DEHCATIA.ViewModels.ProductTree.Rows;
+    using DEHCATIA.ViewModels.Rows;
+
+    using DEHPCommon;
+    using DEHPCommon.HubController.Interfaces;
+
+    using Moq;
+
+    using NUnit.Framework;
+
+    using ProductStructureTypeLib;
+
+    [TestFixture]
+    public class ElementToCatiaRuleTestFixture
+    {
+        private ElementToCatiaRule rule;
+        private ElementDefinition elementDefinition;
+        private ParameterType booleanParameterType;
+        private TextParameterType textParameterType;
+        private QuantityKind quantityParameterType;
+        private Mock<IHubController> hubController;
+        private Mock<IDstController> dstController;
+        private Mock<IParameterTypeService> parameterTypeService;
+        private EnumerationParameterType enumerationParameterType;
+        private Mock<ICatiaTemplateService> catiaTemplateService;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.hubController = new Mock<IHubController>();
+            this.dstController = new Mock<IDstController>();
+            this.parameterTypeService = new Mock<IParameterTypeService>();
+            this.catiaTemplateService = new Mock<ICatiaTemplateService>();
+
+            var containerBuilder = new ContainerBuilder();
+            containerBuilder.RegisterInstance(this.hubController.Object).As<IHubController>();
+            containerBuilder.RegisterInstance(this.dstController.Object).As<IDstController>();
+            containerBuilder.RegisterInstance(this.catiaTemplateService.Object).As<ICatiaTemplateService>();
+            containerBuilder.RegisterInstance(this.parameterTypeService.Object).As<IParameterTypeService>();
+            AppContainer.Container = containerBuilder.Build();
+
+            this.booleanParameterType = new BooleanParameterType(Guid.NewGuid(), null, null);
+            this.enumerationParameterType = new EnumerationParameterType(Guid.NewGuid(), null, null)
+            {
+                ValueDefinition =
+                {
+                    new EnumerationValueDefinition() { ShortName = "CappedCone"}, 
+                    new EnumerationValueDefinition() { ShortName = "Box"},
+                    new EnumerationValueDefinition() { ShortName = "Triangle"}
+                }
+            };
+            this.textParameterType = new TextParameterType(Guid.NewGuid(), null, null);
+
+            var measurementScale = new RatioScale()
+            {
+                NumberSet = NumberSetKind.REAL_NUMBER_SET
+            };
+
+            this.quantityParameterType = new SimpleQuantityKind(Guid.NewGuid(), null, null)
+            {
+                DefaultScale = measurementScale, PossibleScale = { measurementScale }
+            };
+
+            this.rule = new ElementToCatiaRule();
+
+            this.elementDefinition = new ElementDefinition()
+            {
+                Parameter =
+                {
+                    new Parameter()
+                    {
+                        ParameterType = this.booleanParameterType,
+                        ValueSet =
+                        {
+                            new ParameterValueSet()
+                            {
+                                Manual = new ValueArray<string>(new List<string>() { "true" }),
+                                ValueSwitch = ParameterSwitchKind.MANUAL
+                            }
+                        }
+                    },
+                    new Parameter()
+                    {
+                        ParameterType = this.textParameterType,
+                        ValueSet =
+                        {
+                            new ParameterValueSet()
+                            {
+                                Manual = new ValueArray<string>(new List<string>() { "text" }),
+                                ValueSwitch = ParameterSwitchKind.MANUAL
+                            }
+                        }
+                    },
+                    new Parameter()
+                    {
+                        ParameterType = this.quantityParameterType,
+                        Scale = measurementScale,
+                        ValueSet =
+                        {
+                            new ParameterValueSet()
+                            {
+                                Manual = new ValueArray<string>(new List<string>() { "2", "0,42" }),
+                                ValueSwitch = ParameterSwitchKind.MANUAL
+                            }
+                        }
+                    },
+                    new Parameter()
+                    {
+                        ParameterType = this.enumerationParameterType,
+                        ValueSet =
+                        {
+                            new ParameterValueSet()
+                            {
+                                Manual = new ValueArray<string>(new List<string>() { "box" }),
+                                ValueSwitch = ParameterSwitchKind.MANUAL
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        [Test]
+        public void VerifyGetParameterValue()
+        {
+            var mappedElementRowViewModel = new MappedElementRowViewModel() { CatiaElement = new ElementRowViewModel(new Mock<ProductStructureTypeLib.Product>().Object, "") };
+
+            IEnumerable<bool> boolResult = new List<bool>();
+            Assert.DoesNotThrow(() => boolResult = this.rule.GetParameterValue<bool>(this.elementDefinition.Parameter, this.booleanParameterType.Iid, mappedElementRowViewModel));
+            Assert.AreEqual(1, boolResult.Count());
+            Assert.IsTrue(boolResult.FirstOrDefault());
+
+            IEnumerable<double> doubleResult = new List<double>();
+            Assert.DoesNotThrow(() => doubleResult = this.rule.GetParameterValue<double>(this.elementDefinition.Parameter, this.quantityParameterType.Iid, mappedElementRowViewModel));
+            Assert.AreEqual(2, doubleResult.Count());
+            Assert.AreEqual(.42, doubleResult.Last());
+
+            IEnumerable<string> stringResult = new List<string>();
+            Assert.DoesNotThrow(() => stringResult = this.rule.GetParameterValue<string>(this.elementDefinition.Parameter, this.textParameterType.Iid, mappedElementRowViewModel));
+            Assert.AreEqual(1, stringResult.Count());
+            Assert.AreEqual("text", stringResult.FirstOrDefault());
+
+            IEnumerable<ShapeKind> enumResult = new List<ShapeKind>();
+            Assert.DoesNotThrow(() => enumResult = this.rule.GetParameterEnumValue<ShapeKind>(this.elementDefinition.Parameter, this.enumerationParameterType.Iid, mappedElementRowViewModel));
+            Assert.AreEqual(1, enumResult.Count());
+            Assert.AreEqual(ShapeKind.Box, enumResult.FirstOrDefault());
+
+            Assert.IsEmpty(this.rule.MappingErrors);
+            IEnumerable<double> badResult = new List<double>();
+            Assert.DoesNotThrow(() => badResult = this.rule.GetParameterValue<double>(this.elementDefinition.Parameter, this.textParameterType.Iid, mappedElementRowViewModel));
+            Assert.AreEqual(0, badResult.Count());
+            Assert.IsNotEmpty(this.rule.MappingErrors);
+        }
+        
+        [Test]
+        public void VerifyMap()
+        {
+            var path = string.Empty;
+            
+            this.catiaTemplateService.Setup(x => 
+                x.TryGetFileName(It.IsAny<ParameterOrOverrideBase>(), It.IsAny<Option>(), It.IsAny<ActualFiniteState>(), out path)).Returns(true);
+
+            this.parameterTypeService.Setup(x => x.ShapeKind).Returns(this.enumerationParameterType);
+            this.parameterTypeService.Setup(x => x.ShapeAngle).Returns(this.quantityParameterType);
+
+            var mappedElement = new List<MappedElementRowViewModel>()
+            {
+                new MappedElementRowViewModel()
+                {
+                    HubElement = this.elementDefinition,
+                    CatiaParent = new ElementRowViewModel(new Mock<Product>().Object, ""),
+                    ShouldCreateNewElement = true
+                }
+            };
+
+            Assert.DoesNotThrow(() => this.rule.Transform(mappedElement));
+            Assert.IsNotEmpty(mappedElement);
+            Assert.True(mappedElement.First().CatiaElement?.IsDraft);
+            Assert.AreEqual(2, this.rule.MappingErrors.Count);
+        }
+    }
+}

--- a/DEHCATIA.Tests/Services/CatiaTemplateService/CatiaTemplateServiceTestFixture.cs
+++ b/DEHCATIA.Tests/Services/CatiaTemplateService/CatiaTemplateServiceTestFixture.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA.Tests/Services/CatiaTemplateService/CatiaTemplateServiceTestFixture.cs
+++ b/DEHCATIA.Tests/Services/CatiaTemplateService/CatiaTemplateServiceTestFixture.cs
@@ -1,0 +1,81 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CatiaTemplateServiceTestFixture.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.Tests.Services.CatiaTemplateService
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+
+    using CDP4Common.EngineeringModelData;
+    using CDP4Common.SiteDirectoryData;
+    using CDP4Common.Types;
+
+    using DEHCATIA.Services.CatiaTemplateService;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CatiaTemplateServiceTestFixture
+    {
+        private CatiaTemplateService service;
+        private Parameter shapeKindParameter;
+        private EnumerationParameterType enumerationParameterType;
+
+        [SetUp]
+        public void Setup()
+        {
+            this.enumerationParameterType = new EnumerationParameterType(Guid.NewGuid(), null, null)
+            {
+                ValueDefinition =
+                {
+                    new EnumerationValueDefinition() { ShortName = "CappedCone"},
+                    new EnumerationValueDefinition() { ShortName = "Box"},
+                    new EnumerationValueDefinition() { ShortName = "Triangle"}
+                }
+            };
+
+            this.shapeKindParameter = new Parameter()
+            {
+                ParameterType = this.enumerationParameterType,
+                ValueSet =
+                {
+                    new ParameterValueSet()
+                    {
+                        Manual = new ValueArray<string>(new List<string>() { "box" }),
+                        ValueSwitch = ParameterSwitchKind.MANUAL
+                    }
+                }
+            };
+
+            this.service = new CatiaTemplateService();
+        }
+
+        [Test]
+        public void VerifyTryGetFileName()
+        {
+            Assert.Throws<DirectoryNotFoundException>(() => this.service.TryGetFileName(this.shapeKindParameter, null, null, out var path));
+        }
+    }
+}

--- a/DEHCATIA.Tests/Services/ParameterTypeService/ParameterTypeServiceTestFixture.cs
+++ b/DEHCATIA.Tests/Services/ParameterTypeService/ParameterTypeServiceTestFixture.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA.Tests/ViewModels/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/Dialogs/DstMappingConfigurationDialogViewModelTestFixture.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA.Tests/ViewModels/Dialogs/HubMappingConfigurationDialogViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/Dialogs/HubMappingConfigurationDialogViewModelTestFixture.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA.Tests/ViewModels/DstProductTreeViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/DstProductTreeViewModelTestFixture.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA.sln.DotSettings
+++ b/DEHCATIA.sln.DotSettings
@@ -248,14 +248,14 @@
 &#xD;
    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.&#xD;
 &#xD;
-   This file is part of DEHPEcosimPro&#xD;
+   This file is part of DEHCATIA&#xD;
 &#xD;
-   The DEHPEcosimPro is free software; you can redistribute it and/or&#xD;
+   The DEHCATIA is free software; you can redistribute it and/or&#xD;
    modify it under the terms of the GNU Lesser General Public&#xD;
    License as published by the Free Software Foundation; either&#xD;
    version 3 of the License, or (at your option) any later version.&#xD;
 &#xD;
-   The DEHPEcosimPro is distributed in the hope that it will be useful,&#xD;
+   The DEHCATIA is distributed in the hope that it will be useful,&#xD;
    but WITHOUT ANY WARRANTY; without even the implied warranty of&#xD;
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU&#xD;
    Lesser General Public License for more details.&#xD;

--- a/DEHCATIA/App.xaml.cs
+++ b/DEHCATIA/App.xaml.cs
@@ -33,6 +33,7 @@ namespace DEHCATIA
     using Autofac;
 
     using DEHCATIA.DstController;
+    using DEHCATIA.Services.CatiaTemplateService;
     using DEHCATIA.Services.ComConnector;
     using DEHCATIA.Services.ParameterTypeService;
     using DEHCATIA.ViewModels;
@@ -140,6 +141,7 @@ namespace DEHCATIA
             containerBuilder.RegisterType<DstController.DstController>().As<IDstController>().SingleInstance();
             containerBuilder.RegisterType<CatiaComService>().As<ICatiaComService>().SingleInstance();
             containerBuilder.RegisterType<ParameterTypeService>().As<IParameterTypeService>().SingleInstance();
+            containerBuilder.RegisterType<CatiaTemplateService>().As<ICatiaTemplateService>();
         }
 
         /// <summary>

--- a/DEHCATIA/Events/DstHighlightEvent.cs
+++ b/DEHCATIA/Events/DstHighlightEvent.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/Events/UpdateDstElementTreeEvent.cs
+++ b/DEHCATIA/Events/UpdateDstElementTreeEvent.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/Events/UpdateDstPreviewBasedOnSelectionEvent.cs
+++ b/DEHCATIA/Events/UpdateDstPreviewBasedOnSelectionEvent.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/Events/UpdateHubPreviewBasedOnSelectionEvent.cs
+++ b/DEHCATIA/Events/UpdateHubPreviewBasedOnSelectionEvent.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/MappingRules/ElementToCatiaRule.cs
+++ b/DEHCATIA/MappingRules/ElementToCatiaRule.cs
@@ -149,58 +149,58 @@ namespace DEHCATIA.MappingRules
             }
 
             mappedElementRowViewModel.CatiaElement.Shape.Angle =
-                this.GetNewParameterValue(mappedElementRowViewModel, parameters, 
+                this.RefreshOrCreateDoubleWithUnitValueViewModel(mappedElementRowViewModel, parameters, 
                     mappedElementRowViewModel.CatiaElement.Shape.Angle, this.parameterTypeService.ShapeAngle?.Iid);
 
             mappedElementRowViewModel.CatiaElement.Shape.AngleSupport =
-                this.GetNewParameterValue(mappedElementRowViewModel, parameters, 
+                this.RefreshOrCreateDoubleWithUnitValueViewModel(mappedElementRowViewModel, parameters, 
                     mappedElementRowViewModel.CatiaElement.Shape.AngleSupport, this.parameterTypeService.ShapeSupportAngle?.Iid);
 
-            mappedElementRowViewModel.CatiaElement.Shape.Area = this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+            mappedElementRowViewModel.CatiaElement.Shape.Area = this.RefreshOrCreateDoubleWithUnitValueViewModel(mappedElementRowViewModel, parameters,
                 mappedElementRowViewModel.CatiaElement.Shape.Area, this.parameterTypeService.ShapeArea?.Iid);
 
             mappedElementRowViewModel.CatiaElement.Shape.Density =
-                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                this.RefreshOrCreateDoubleWithUnitValueViewModel(mappedElementRowViewModel, parameters,
                     mappedElementRowViewModel.CatiaElement.Shape.Density, this.parameterTypeService.ShapeDensity?.Iid);
 
             mappedElementRowViewModel.CatiaElement.Shape.Height =
-                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                this.RefreshOrCreateDoubleWithUnitValueViewModel(mappedElementRowViewModel, parameters,
                     mappedElementRowViewModel.CatiaElement.Shape.Height, this.parameterTypeService.ShapeHeight?.Iid);
 
             mappedElementRowViewModel.CatiaElement.Shape.WidthOrDiameter =
-                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                this.RefreshOrCreateDoubleWithUnitValueViewModel(mappedElementRowViewModel, parameters,
                     mappedElementRowViewModel.CatiaElement.Shape.WidthOrDiameter, this.parameterTypeService.ShapeWidthOrDiameter?.Iid);
 
             mappedElementRowViewModel.CatiaElement.Shape.Length =
-                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                this.RefreshOrCreateDoubleWithUnitValueViewModel(mappedElementRowViewModel, parameters,
                     mappedElementRowViewModel.CatiaElement.Shape.Length, this.parameterTypeService.ShapeLength?.Iid);
 
             mappedElementRowViewModel.CatiaElement.Shape.LengthSupport =
-                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                this.RefreshOrCreateDoubleWithUnitValueViewModel(mappedElementRowViewModel, parameters,
                     mappedElementRowViewModel.CatiaElement.Shape.LengthSupport, this.parameterTypeService.ShapeSupportLength?.Iid);
 
             mappedElementRowViewModel.CatiaElement.Shape.Mass =
-                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                this.RefreshOrCreateDoubleWithUnitValueViewModel(mappedElementRowViewModel, parameters,
                     mappedElementRowViewModel.CatiaElement.Shape.Mass, this.parameterTypeService.Mass?.Iid);
 
             mappedElementRowViewModel.CatiaElement.Shape.MassMargin =
-                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                this.RefreshOrCreateDoubleWithUnitValueViewModel(mappedElementRowViewModel, parameters,
                     mappedElementRowViewModel.CatiaElement.Shape.MassMargin, this.parameterTypeService.ShapeMassMargin?.Iid);
 
             mappedElementRowViewModel.CatiaElement.Shape.MassWithMargin =
-                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                this.RefreshOrCreateDoubleWithUnitValueViewModel(mappedElementRowViewModel, parameters,
                     mappedElementRowViewModel.CatiaElement.Shape.MassWithMargin, this.parameterTypeService.ShapeMassWithMargin?.Iid);
 
             mappedElementRowViewModel.CatiaElement.Shape.SysMassMargin =
-                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                this.RefreshOrCreateDoubleWithUnitValueViewModel(mappedElementRowViewModel, parameters,
                     mappedElementRowViewModel.CatiaElement.Shape.SysMassMargin, this.parameterTypeService.ShapeSysMassMargin?.Iid);
 
             mappedElementRowViewModel.CatiaElement.Shape.Thickness =
-                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                this.RefreshOrCreateDoubleWithUnitValueViewModel(mappedElementRowViewModel, parameters,
                     mappedElementRowViewModel.CatiaElement.Shape.Thickness, this.parameterTypeService.ShapeThickness?.Iid);
 
             mappedElementRowViewModel.CatiaElement.Shape.Volume =
-                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                this.RefreshOrCreateDoubleWithUnitValueViewModel(mappedElementRowViewModel, parameters,
                     mappedElementRowViewModel.CatiaElement.Shape.Volume, this.parameterTypeService.Volume?.Iid);
 
             mappedElementRowViewModel.CatiaElement.Shape.ExternalShape = 
@@ -217,7 +217,7 @@ namespace DEHCATIA.MappingRules
         /// <param name="parameter">The <see cref="DoubleWithUnitValueViewModel"/></param>
         /// <param name="parameterTypeIid">The <see cref="Guid"/> Id of the <see cref="ParameterType"/></param>
         /// <returns>An updated <see cref="DoubleWithUnitValueViewModel"/></returns>
-        private DoubleWithUnitValueViewModel GetNewParameterValue(MappedElementRowViewModel mappedElementRowViewModel, IEnumerable<ParameterOrOverrideBase> parameters, DoubleWithUnitValueViewModel parameter, Guid? parameterTypeIid)
+        private DoubleWithUnitValueViewModel RefreshOrCreateDoubleWithUnitValueViewModel(MappedElementRowViewModel mappedElementRowViewModel, IEnumerable<ParameterOrOverrideBase> parameters, DoubleWithUnitValueViewModel parameter, Guid? parameterTypeIid)
         {
             var newAngleValue = parameterTypeIid.HasValue 
                 ? this.GetParameterValues<double>(parameters, parameterTypeIid.Value, mappedElementRowViewModel)?.FirstOrDefault()

--- a/DEHCATIA/MappingRules/ElementToCatiaRule.cs
+++ b/DEHCATIA/MappingRules/ElementToCatiaRule.cs
@@ -25,19 +25,27 @@
 namespace DEHCATIA.MappingRules
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
     using System.Runtime.ExceptionServices;
 
     using Autofac;
 
     using CDP4Common.EngineeringModelData;
+    using CDP4Common.Helpers;
+    using CDP4Common.SiteDirectoryData;
 
-    using DEHCATIA.DstController;
+    using DEHCATIA.Enumerations;
+    using DEHCATIA.Services.CatiaTemplateService;
+    using DEHCATIA.Services.ParameterTypeService;
+    using DEHCATIA.ViewModels.ProductTree.Parameters;
     using DEHCATIA.ViewModels.ProductTree.Rows;
+    using DEHCATIA.ViewModels.ProductTree.Shapes;
     using DEHCATIA.ViewModels.Rows;
 
     using DEHPCommon;
+    using DEHPCommon.HubController.Interfaces;
     using DEHPCommon.MappingRules.Core;
 
     using NLog;
@@ -50,12 +58,32 @@ namespace DEHCATIA.MappingRules
         /// <summary>
         /// The current class logger
         /// </summary>
-        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
+        private readonly Logger logger = LogManager.GetCurrentClassLogger();
 
         /// <summary>
-        /// The collection of <see cref="ElementRowViewModel"/> that results of the <see cref="Transform"/>
+        /// The <see cref="IHubController"/>
         /// </summary>
-        private readonly List<MappedElementRowViewModel> ruleOutput = new List<MappedElementRowViewModel>();
+        private readonly IHubController hubController = AppContainer.Container.Resolve<IHubController>();
+
+        /// <summary>
+        /// The <see cref="IParameterTypeService"/>
+        /// </summary>
+        private readonly IParameterTypeService parameterTypeService = AppContainer.Container.Resolve<IParameterTypeService>();
+
+        /// <summary>
+        /// The <see cref="ICatiaTemplateService"/>
+        /// </summary>
+        private readonly ICatiaTemplateService catiaTemplateService = AppContainer.Container.Resolve<ICatiaTemplateService>();
+
+        /// <summary>
+        /// Gets the collection of error messages from <see cref="mappingErrors"/>
+        /// </summary>
+        public IReadOnlyList<string> MappingErrors => this.mappingErrors.AsReadOnly();
+
+        /// <summary>
+        /// The private collection of mapping errors
+        /// </summary>
+        private readonly List<string> mappingErrors = new List<string>();
 
         /// <summary>
         /// Transforms <see cref="MappedElementRowViewModel" /> to a <see cref="ElementRowViewModel" />
@@ -64,21 +92,350 @@ namespace DEHCATIA.MappingRules
         {
             try
             {
-                this.Map(input);
+                var mappedElementRowViewModels = input as MappedElementRowViewModel[] ?? input.ToArray();
 
-                return this.ruleOutput;
+                this.Map(mappedElementRowViewModels);
+
+                return mappedElementRowViewModels;
             }
             catch (Exception exception)
             {
-                Logger.Error(exception);
+                this.logger.Error(exception);
                 ExceptionDispatchInfo.Capture(exception).Throw();
                 return default;
             }
         }
 
+        /// <summary>
+        /// Maps the <see cref="input"/>
+        /// </summary>
+        /// <param name="input">The collection of <see cref="MappedElementRowViewModel"/> containing the informations about the things that were mapped</param>
         private void Map(IEnumerable<MappedElementRowViewModel> input)
         {
-            throw new NotImplementedException();
+            foreach (var mappedElementRowViewModel in input)
+            {
+                if (mappedElementRowViewModel.ShouldCreateNewElement
+                    && mappedElementRowViewModel.CatiaParent != null
+                    && !this.CreateCatiaElement(mappedElementRowViewModel))
+                {
+                    continue;
+                }
+
+                this.MapPosition(mappedElementRowViewModel);
+                this.MapOrientation(mappedElementRowViewModel);
+                this.MapParameters(mappedElementRowViewModel);
+            }
+        }
+
+        /// <summary>
+        /// Maps the parameters of <see cref="MappedElementRowViewModel.HubElement"/> from <paramref name="mappedElementRowViewModel"/>
+        /// </summary>
+        /// <param name="mappedElementRowViewModel">The <see cref="MappedElementRowViewModel"/></param>
+        private void MapParameters(MappedElementRowViewModel mappedElementRowViewModel)
+        {
+            var parameters = this.GetParameters(mappedElementRowViewModel.HubElement).ToArray();
+
+            if (mappedElementRowViewModel.CatiaElement.Shape is null
+                && this.GetParameterEnumValue<ShapeKind>(parameters, this.parameterTypeService.ShapeKind.Iid, mappedElementRowViewModel)?.FirstOrDefault() is { } shapeKind)
+            {
+                mappedElementRowViewModel.CatiaElement.Shape = new CatiaShapeViewModel(true) { ShapeKind = shapeKind };
+            }
+            else
+            {
+                var message = $"The shape kind described in the element {mappedElementRowViewModel.HubElement.Name} isn't supported by either Catia or the adapter";
+                this.mappingErrors.Add(message);
+                this.logger.Warn(message);
+                return;
+            }
+
+            mappedElementRowViewModel.CatiaElement.Shape.Angle =
+                this.GetNewParameterValue(mappedElementRowViewModel, parameters, 
+                    mappedElementRowViewModel.CatiaElement.Shape.Angle, this.parameterTypeService.ShapeAngle?.Iid);
+
+            mappedElementRowViewModel.CatiaElement.Shape.AngleSupport =
+                this.GetNewParameterValue(mappedElementRowViewModel, parameters, 
+                    mappedElementRowViewModel.CatiaElement.Shape.AngleSupport, this.parameterTypeService.ShapeSupportAngle?.Iid);
+
+            mappedElementRowViewModel.CatiaElement.Shape.Area = this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                mappedElementRowViewModel.CatiaElement.Shape.Area, this.parameterTypeService.ShapeArea?.Iid);
+
+            mappedElementRowViewModel.CatiaElement.Shape.Density =
+                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                    mappedElementRowViewModel.CatiaElement.Shape.Density, this.parameterTypeService.ShapeDensity?.Iid);
+
+            mappedElementRowViewModel.CatiaElement.Shape.Height =
+                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                    mappedElementRowViewModel.CatiaElement.Shape.Height, this.parameterTypeService.ShapeHeight?.Iid);
+
+            mappedElementRowViewModel.CatiaElement.Shape.WidthOrDiameter =
+                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                    mappedElementRowViewModel.CatiaElement.Shape.WidthOrDiameter, this.parameterTypeService.ShapeWidthOrDiameter?.Iid);
+
+            mappedElementRowViewModel.CatiaElement.Shape.Length =
+                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                    mappedElementRowViewModel.CatiaElement.Shape.Length, this.parameterTypeService.ShapeLength?.Iid);
+
+            mappedElementRowViewModel.CatiaElement.Shape.LengthSupport =
+                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                    mappedElementRowViewModel.CatiaElement.Shape.LengthSupport, this.parameterTypeService.ShapeSupportLength?.Iid);
+
+            mappedElementRowViewModel.CatiaElement.Shape.Mass =
+                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                    mappedElementRowViewModel.CatiaElement.Shape.Mass, this.parameterTypeService.Mass?.Iid);
+
+            mappedElementRowViewModel.CatiaElement.Shape.MassMargin =
+                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                    mappedElementRowViewModel.CatiaElement.Shape.MassMargin, this.parameterTypeService.ShapeMassMargin?.Iid);
+
+            mappedElementRowViewModel.CatiaElement.Shape.MassWithMargin =
+                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                    mappedElementRowViewModel.CatiaElement.Shape.MassWithMargin, this.parameterTypeService.ShapeMassWithMargin?.Iid);
+
+            mappedElementRowViewModel.CatiaElement.Shape.SysMassMargin =
+                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                    mappedElementRowViewModel.CatiaElement.Shape.SysMassMargin, this.parameterTypeService.ShapeSysMassMargin?.Iid);
+
+            mappedElementRowViewModel.CatiaElement.Shape.Thickness =
+                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                    mappedElementRowViewModel.CatiaElement.Shape.Thickness, this.parameterTypeService.ShapeThickness?.Iid);
+
+            mappedElementRowViewModel.CatiaElement.Shape.Volume =
+                this.GetNewParameterValue(mappedElementRowViewModel, parameters,
+                    mappedElementRowViewModel.CatiaElement.Shape.Volume, this.parameterTypeService.Volume?.Iid);
+
+            mappedElementRowViewModel.CatiaElement.Shape.ExternalShape = 
+                this.GetParameterValue<string>(parameters, this.parameterTypeService.ExternalShape?.Iid, mappedElementRowViewModel)?
+                    .FirstOrDefault()
+                ?? mappedElementRowViewModel.CatiaElement.Shape.ExternalShape;
+        }
+
+        /// <summary>
+        /// Gets the new value out of the right <see cref="ParameterOrOverrideBase"/> from <paramref name="parameters"/> for the <paramref name="parameter"/>
+        /// </summary>
+        /// <param name="mappedElementRowViewModel">The current <see cref="MappedElementRowViewModel"/></param>
+        /// <param name="parameters">The collection of <see cref="ParameterOrOverrideBase"/></param>
+        /// <param name="parameter">The <see cref="DoubleWithUnitValueViewModel"/></param>
+        /// <param name="parameterTypeIid">The <see cref="Guid"/> Id of the <see cref="ParameterType"/></param>
+        /// <returns>An updated <see cref="DoubleWithUnitValueViewModel"/></returns>
+        private DoubleWithUnitValueViewModel GetNewParameterValue(MappedElementRowViewModel mappedElementRowViewModel, IEnumerable<ParameterOrOverrideBase> parameters, DoubleWithUnitValueViewModel parameter, Guid? parameterTypeIid)
+        {
+            var newAngleValue = parameterTypeIid.HasValue 
+                ? this.GetParameterValue<double>(parameters, parameterTypeIid.Value, mappedElementRowViewModel)?.FirstOrDefault()
+                : null;
+
+            if (!newAngleValue.HasValue)
+            {
+                return parameter;
+            }
+
+            if (mappedElementRowViewModel.CatiaElement.Shape.Angle is null)
+            {
+                return new DoubleWithUnitValueViewModel(newAngleValue.Value);
+            }
+
+            parameter.Value = newAngleValue.Value;
+            return parameter;
+        }
+
+        /// <summary>
+        /// Get the values typed as <typeparamref name="TValueType"/> out of a value set from the <paramref name="parameter"/>
+        /// </summary>
+        /// <typeparam name="TValueType">The type of the collection of values to return where <typeparamref name="TValueType"/> is <see cref="IConvertible"/></typeparam>
+        /// <param name="parameter">The <see cref="ParameterBase"/></param>
+        /// <param name="mappedElementRowViewModel">The <see cref="MappedElementRowViewModel"/></param>
+        /// <returns>A collection of <typeparamref name="TValueType"/></returns>
+        private IEnumerable<TValueType> GetValue<TValueType>(ParameterBase parameter, MappedElementRowViewModel mappedElementRowViewModel) where TValueType : IConvertible
+        {
+            var valueSet = parameter.QueryParameterBaseValueSet(mappedElementRowViewModel.CatiaElement.SelectedOption, mappedElementRowViewModel.CatiaElement.SelectedActualFiniteState);
+
+            var values = new List<TValueType>();
+
+            foreach (var value in valueSet.ActualValue)
+            {
+                if (typeof(TValueType) == typeof(double)
+                    && ValueSetConverter.TryParseDouble(value, parameter.ParameterType, out var output)
+                    && output is TValueType result)
+                {
+                    values.Add(result);
+                }
+                else if (value.ToValueSetObject(parameter.ParameterType) is TValueType convertedValue)
+                {
+                    values.Add(convertedValue);
+                }
+                else
+                {
+                    var errorMessage = $"The value {value} from Parameter {parameter.ModelCode()} could not be parsed as {typeof(TValueType).Name}";
+                    this.mappingErrors.Add(errorMessage);
+                    this.logger.Warn(errorMessage);
+                }
+            }
+
+            return values;
+        }
+
+        /// <summary>
+        /// Get the values typed as <typeparamref name="TEnum"/> out of a value set from the <paramref name="parameter"/>
+        /// </summary>
+        /// <typeparam name="TEnum">The type of the collection of values to return where <typeparamref name="TEnum"/> is <see cref="IConvertible"/></typeparam>
+        /// <param name="parameter">The <see cref="ParameterBase"/></param>
+        /// <param name="mappedElementRowViewModel">The <see cref="MappedElementRowViewModel"/></param>
+        /// <returns>A collection of <typeparamref name="TEnum"/></returns>
+        private IEnumerable<TEnum> GetEnumValue<TEnum>(ParameterBase parameter, MappedElementRowViewModel mappedElementRowViewModel) where TEnum : struct, Enum
+        {
+            var valueSet = parameter.QueryParameterBaseValueSet(mappedElementRowViewModel.CatiaElement.SelectedOption, mappedElementRowViewModel.CatiaElement.SelectedActualFiniteState);
+
+            var values = new List<TEnum>();
+
+            foreach (var value in valueSet.ActualValue)
+            {
+                if(Enum.TryParse(value, true, out TEnum enumResult))
+                {
+                    values.Add(enumResult);
+                }
+                else
+                {
+                    var errorMessage = $"The value {value} from Parameter {parameter.ModelCode()} could not be parsed as Enum {typeof(TEnum).Name}";
+                    this.mappingErrors.Add(errorMessage);
+                    this.logger.Warn(errorMessage);
+                }
+            }
+
+            return values;
+        }
+
+        /// <summary>
+        /// Get the values typed as <typeparamref name="TValueType"/> out of a value set from one of the <paramref name="parameters"/>
+        /// </summary>
+        /// <typeparam name="TValueType">The type of the collection of values to return where <typeparamref name="TValueType"/> is <see cref="IConvertible"/></typeparam>
+        /// <param name="parameters">The collection of <see cref="ParameterOrOverrideBase"/></param>
+        /// <param name="parameterTypeIid">The <see cref="ParameterType"/> Iid</param>
+        /// <param name="mappedElementRowViewModel">The <see cref="MappedElementRowViewModel"/></param>
+        /// <returns>A collection of <typeparamref name="TValueType"/></returns>
+        public IEnumerable<TValueType> GetParameterValue<TValueType>(IEnumerable<ParameterOrOverrideBase> parameters, Guid? parameterTypeIid, MappedElementRowViewModel mappedElementRowViewModel) 
+            where TValueType : IConvertible
+        {
+            var parameter = parameters.FirstOrDefault(x => x.ParameterType.Iid == parameterTypeIid);
+
+            return parameter is null 
+                ? new List<TValueType>() 
+                : this.GetValue<TValueType>(parameter, mappedElementRowViewModel);
+        }
+
+        /// <summary>
+        /// Get the values typed as <typeparamref name="TEnum"/> out of a value set from one of the <paramref name="parameters"/>
+        /// </summary>
+        /// <typeparam name="TEnum">The type of the collection of values to return where <typeparamref name="TEnum"/> is <see cref="Enum"/></typeparam>
+        /// <param name="parameters">The collection of <see cref="ParameterOrOverrideBase"/></param>
+        /// <param name="parameterTypeIid">The <see cref="ParameterType"/> Iid</param>
+        /// <param name="mappedElementRowViewModel">The <see cref="MappedElementRowViewModel"/></param>
+        /// <returns>A collection of <typeparamref name="TEnum"/></returns>
+        public IEnumerable<TEnum> GetParameterEnumValue<TEnum>(IEnumerable<ParameterOrOverrideBase> parameters, Guid parameterTypeIid, MappedElementRowViewModel mappedElementRowViewModel) 
+            where TEnum : struct, Enum
+        {
+            var parameter = parameters.FirstOrDefault(x => x.ParameterType.Iid == parameterTypeIid);
+
+            return parameter is null 
+                ? new List<TEnum>() 
+                : this.GetEnumValue<TEnum>(parameter, mappedElementRowViewModel);
+        }
+
+        /// <summary>
+        /// Gets one parameter out of the <paramref name="hubElement"/> where the parameter type is <see cref="parameterType"/>
+        /// </summary>
+        /// <param name="hubElement">The <see cref="ElementBase"/></param>
+        /// <param name="parameterType">The <see cref="ParameterType"/></param>
+        /// <returns>A <see cref="ParameterOrOverrideBase"/></returns>
+        private ParameterOrOverrideBase GetParameter(ElementBase hubElement, ParameterType parameterType)
+        {
+            return this.GetParameters(hubElement)
+                .FirstOrDefault(x => x.ParameterType.Iid == parameterType?.Iid);
+        }
+
+        /// <summary>
+        /// Gets the collection of parameter out of the <paramref name="hubElement"/>
+        /// </summary>
+        /// <param name="hubElement">The <see cref="ElementBase"/></param>
+        /// <returns>A collection of <see cref="ParameterOrOverrideBase"/></returns>
+        private IEnumerable<ParameterOrOverrideBase> GetParameters(ElementBase hubElement)
+        {
+            Func<IEnumerable<ParameterOrOverrideBase>> parameters = hubElement switch
+            {
+                ElementDefinition elementDefinition => () => elementDefinition.Parameter,
+                ElementUsage elementUsage => () =>
+                {
+                    var parameterOrOveride = new List<ParameterOrOverrideBase>(elementUsage.ParameterOverride);
+                    var overridenParameter = elementUsage.ParameterOverride.Select(x => x.Parameter).ToList();
+                    parameterOrOveride.AddRange(elementUsage.ElementDefinition.Parameter.Except(overridenParameter).ToList());
+                    return parameterOrOveride;
+                },
+                _ => throw new ArgumentOutOfRangeException(nameof(hubElement))
+            };
+
+            return parameters.Invoke();
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ElementRowViewModel"/> when the <see cref="MappedElementRowViewModel.HubElement"/> does not exist yet in the Catia model
+        /// </summary>
+        /// <param name="mappedElementRowViewModel">The <see cref="MappedElementRowViewModel"/></param>
+        /// <returns>A value indicating whether the Catia element draft has been created</returns>
+        private bool CreateCatiaElement(MappedElementRowViewModel mappedElementRowViewModel)
+        {
+            if (this.catiaTemplateService.TryGetFileName(
+                this.GetParameter(mappedElementRowViewModel.HubElement, this.parameterTypeService.ShapeKind),
+                mappedElementRowViewModel.CatiaParent.SelectedOption, mappedElementRowViewModel.CatiaParent.SelectedActualFiniteState,
+                out var fileName))
+            {
+                mappedElementRowViewModel.CatiaElement = new ElementRowViewModel(mappedElementRowViewModel.HubElement, fileName);
+                return true;
+            }
+
+            this.mappingErrors.Add($"No template shape has been found based on the element {mappedElementRowViewModel.HubElement.Name}");
+            return false;
+        }
+
+        /// <summary>
+        /// Maps the position parameter
+        /// </summary>
+        /// <param name="mappedElementRowViewModel">The <see cref="MappedElementRowViewModel"/></param>
+        private void MapPosition(MappedElementRowViewModel mappedElementRowViewModel)
+        {
+            var valueSet = this.GetParameter(mappedElementRowViewModel.HubElement, this.parameterTypeService.Position)?
+                .QueryParameterBaseValueSet(mappedElementRowViewModel.CatiaElement.SelectedOption,
+                    mappedElementRowViewModel.CatiaElement.SelectedActualFiniteState);
+
+            if (valueSet?.ActualValue.Count != 3)
+            {
+                this.mappingErrors.Add($"The position parameter was not found or could not be mapped for the element {mappedElementRowViewModel.HubElement.Name}");
+                return;
+            }
+
+            var positionMatrix = (Convert.ToDouble(valueSet?.ActualValue[0], CultureInfo.InvariantCulture), 
+                Convert.ToDouble(valueSet?.ActualValue[1], CultureInfo.InvariantCulture), 
+                Convert.ToDouble(valueSet?.ActualValue[2], CultureInfo.InvariantCulture));
+
+            mappedElementRowViewModel.CatiaElement.Shape.PositionOrientation.Position = new PositionParameterValueViewModel(positionMatrix);
+        }
+
+        /// <summary>
+        /// Maps the Orientation Parameter
+        /// </summary>
+        /// <param name="mappedElementRowViewModel">The <see cref="MappedElementRowViewModel"/></param>
+        private void MapOrientation(MappedElementRowViewModel mappedElementRowViewModel)
+        {
+            var valueSet = this.GetParameter(mappedElementRowViewModel.HubElement, this.parameterTypeService.Orientation)?
+                .QueryParameterBaseValueSet(mappedElementRowViewModel.CatiaElement.SelectedOption,
+                    mappedElementRowViewModel.CatiaElement.SelectedActualFiniteState);
+
+            var orientationMatrix = valueSet?.ActualValue.Select(x => Convert.ToDouble(x, CultureInfo.InvariantCulture));
+
+            if (orientationMatrix is null)
+            {
+                this.mappingErrors.Add($"The Orientation parameter was not found or could not be mapped for the element {mappedElementRowViewModel.HubElement.Name}");
+                return;
+            }
+
+            mappedElementRowViewModel.CatiaElement.Shape.PositionOrientation.Orientation = new OrientationViewModel(orientationMatrix.ToList());
         }
     }
 }

--- a/DEHCATIA/Services/CatiaTemplateService/CatiaTemplateService.cs
+++ b/DEHCATIA/Services/CatiaTemplateService/CatiaTemplateService.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/Services/CatiaTemplateService/CatiaTemplateService.cs
+++ b/DEHCATIA/Services/CatiaTemplateService/CatiaTemplateService.cs
@@ -1,0 +1,101 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="CatiaTemplateService.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.Services.CatiaTemplateService
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+
+    using CDP4Common.EngineeringModelData;
+
+    using DEHCATIA.Enumerations;
+
+    using NLog;
+
+    /// <summary>
+    /// The <see cref="CatiaTemplateService"/> provides a way to handle file operations related to Catia templates
+    /// </summary>
+    public class CatiaTemplateService : ICatiaTemplateService
+    {
+        /// <summary>
+        /// The directory name at the root of this assembly binaries containing all the Catia templates
+        /// </summary>
+        private const string TemplateDirectory = "Templates";
+        
+        /// <summary>
+        /// The current class logger
+        /// </summary>
+        private readonly Logger logger = LogManager.GetCurrentClassLogger();
+        
+        /// <summary>
+        /// Get the file name from the shape <paramref name="parameter"/> value
+        /// </summary>
+        /// <param name="parameter">The parameter representing the shape kind</param>
+        /// <param name="option">The <see cref="Option"/> in case the <see cref="Parameter"/> is option dependent</param>
+        /// <param name="state">The <see cref="ActualFiniteState"/> in case the <see cref="Parameter"/> is state dependent</param>
+        /// <returns>A path containing the reference path where the shape template is</returns>
+        public string GetFileName(ParameterOrOverrideBase parameter, Option option = null, ActualFiniteState state = null)
+        {
+            return this.TryGetFileName(parameter, option, state, out var shapePath) 
+                ? shapePath 
+                : default;
+        }
+
+        /// <summary>
+        /// Get the file name from the shape <paramref name="parameter"/> value
+        /// </summary>
+        /// <param name="parameter">The parameter representing the shape kind</param>
+        /// <param name="option">The <see cref="Option"/> in case the <see cref="Parameter"/> is option dependent</param>
+        /// <param name="state">The <see cref="ActualFiniteState"/> in case the <see cref="Parameter"/> is state dependent</param>
+        /// <param name="shapePath">The string shape path</param>
+        /// <returns>A value indicating whether the template shapehas been found</returns>
+        public bool TryGetFileName(ParameterOrOverrideBase parameter, Option option, ActualFiniteState state, out string shapePath )
+        {
+            var valueset = parameter.QueryParameterBaseValueSet(option, state);
+
+            shapePath = default;
+
+            if (Enum.TryParse(valueset.ActualValue.FirstOrDefault(), true, out ShapeKind shapeKind) 
+                && this.GetFileName(shapeKind) is {} path)
+            {
+                shapePath = path;
+                return true;
+            }
+
+            this.logger.Warn($"No template shape has been found based on the parameter {parameter.ModelCode()}");
+            return false;
+        }
+
+        /// <summary>
+        /// Get the file name from the provided <paramref name="shapeKind"/>
+        /// </summary>
+        /// <param name="shapeKind">The <see cref="ShapeKind"/></param>
+        /// <returns>A path containing the reference path where the shape template is</returns>
+        private string GetFileName(ShapeKind shapeKind)
+        {
+            return Directory.EnumerateFiles(TemplateDirectory, $"*{shapeKind}*", SearchOption.AllDirectories).FirstOrDefault();
+        }
+    }
+}

--- a/DEHCATIA/Services/CatiaTemplateService/ICatiaTemplateService.cs
+++ b/DEHCATIA/Services/CatiaTemplateService/ICatiaTemplateService.cs
@@ -1,0 +1,53 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="ICatiaTemplateService.cs" company="RHEA System S.A.">
+//    Copyright (c) 2020-2021 RHEA System S.A.
+// 
+//    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
+// 
+//    This file is part of DEHPEcosimPro
+// 
+//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    modify it under the terms of the GNU Lesser General Public
+//    License as published by the Free Software Foundation; either
+//    version 3 of the License, or (at your option) any later version.
+// 
+//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//    Lesser General Public License for more details.
+// 
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with this program; if not, write to the Free Software Foundation,
+//    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace DEHCATIA.Services.CatiaTemplateService
+{
+    using CDP4Common.EngineeringModelData;
+
+    /// <summary>
+    /// The <see cref="ICatiaTemplateService"/> is the interface definition for <see cref="CatiaTemplateService"/>
+    /// </summary>
+    public interface ICatiaTemplateService
+    {
+        /// <summary>
+        /// Get the file name from the shape <paramref name="parameter"/> value
+        /// </summary>
+        /// <param name="parameter">The parameter representing the shape kind</param>
+        /// <param name="option">The <see cref="Option"/> in case the <see cref="Parameter"/> is option dependent</param>
+        /// <param name="state">The <see cref="ActualFiniteState"/> in case the <see cref="Parameter"/> is state dependent</param>
+        /// <returns>A path containing the reference path where the shape template is</returns>
+        string GetFileName(ParameterOrOverrideBase parameter, Option option = null, ActualFiniteState state = null);
+
+        /// <summary>
+        /// Get the file name from the shape <paramref name="parameter"/> value
+        /// </summary>
+        /// <param name="parameter">The parameter representing the shape kind</param>
+        /// <param name="option">The <see cref="Option"/> in case the <see cref="Parameter"/> is option dependent</param>
+        /// <param name="state">The <see cref="ActualFiniteState"/> in case the <see cref="Parameter"/> is state dependent</param>
+        /// <param name="shapePath">The string shape path</param>
+        /// <returns>A value indicating whether the template shapehas been found</returns>
+        bool TryGetFileName(ParameterOrOverrideBase parameter, Option option, ActualFiniteState state, out string shapePath );
+    }
+}

--- a/DEHCATIA/Services/CatiaTemplateService/ICatiaTemplateService.cs
+++ b/DEHCATIA/Services/CatiaTemplateService/ICatiaTemplateService.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/Services/ComConnector/CatiaComService.cs
+++ b/DEHCATIA/Services/ComConnector/CatiaComService.cs
@@ -668,15 +668,5 @@ namespace DEHCATIA.Services.ComConnector
 
             return this.CatiaApp.Documents.Open(fileName);
         }
-
-        /// <summary>
-        /// Updates the position and orientation of the catia element specified in the <paramref name="element"/>
-        /// </summary>
-        /// <param name="element">The <see cref="MappedElementRowViewModel"/></param>
-        private void UpdatePositionAndOrientation(MappedElementRowViewModel element)
-        {
-            //var arrayOftransformation = element.HubElement.
-            //element.CatiaElement.Product.Position.SetComponents();
-        }
     }
 }

--- a/DEHCATIA/Services/ComConnector/CatiaComService.cs
+++ b/DEHCATIA/Services/ComConnector/CatiaComService.cs
@@ -34,12 +34,16 @@ namespace DEHCATIA.Services.ComConnector
     using System.Runtime.InteropServices;
     using System.Threading;
 
+    using CDP4Common.EngineeringModelData;
+
     using DEHCATIA.Enumerations;
     using DEHCATIA.Extensions;
+    using DEHCATIA.Services.ParameterTypeService;
     using DEHCATIA.ViewModels.ProductTree;
     using DEHCATIA.ViewModels.ProductTree.Parameters;
     using DEHCATIA.ViewModels.ProductTree.Rows;
     using DEHCATIA.ViewModels.ProductTree.Shapes;
+    using DEHCATIA.ViewModels.Rows;
 
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
 
@@ -62,6 +66,7 @@ namespace DEHCATIA.Services.ComConnector
     using SPATypeLib;
 
     using File = System.IO.File;
+    using Parameter = KnowledgewareTypeLib.Parameter;
 
     /// <summary>
     /// The <see cref="CatiaComService"/> is responsible for managing the connection with Catia
@@ -87,7 +92,7 @@ namespace DEHCATIA.Services.ComConnector
         /// The cache of read and parsed <see cref="PartDocument"/> as <see cref="DefinitionRowViewModel"/>
         /// </summary>
         private readonly Dictionary<string, DefinitionRowViewModel> catDefinitionCache = new Dictionary<string, DefinitionRowViewModel>();
-
+        
         /// <summary>
         /// Gets or sets whether there's a connection to a running CATIA client.
         /// </summary>
@@ -662,6 +667,16 @@ namespace DEHCATIA.Services.ComConnector
             }
 
             return this.CatiaApp.Documents.Open(fileName);
+        }
+
+        /// <summary>
+        /// Updates the position and orientation of the catia element specified in the <paramref name="element"/>
+        /// </summary>
+        /// <param name="element">The <see cref="MappedElementRowViewModel"/></param>
+        private void UpdatePositionAndOrientation(MappedElementRowViewModel element)
+        {
+            //var arrayOftransformation = element.HubElement.
+            //element.CatiaElement.Product.Position.SetComponents();
         }
     }
 }

--- a/DEHCATIA/Services/ParameterTypeService/IParameterTypeService.cs
+++ b/DEHCATIA/Services/ParameterTypeService/IParameterTypeService.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/Services/ParameterTypeService/IParameterTypeService.cs
+++ b/DEHCATIA/Services/ParameterTypeService/IParameterTypeService.cs
@@ -127,6 +127,11 @@ namespace DEHCATIA.Services.ParameterTypeService
         ParameterType ShapeSysMassMargin { get; }
 
         /// <summary>
+        /// The Shape external shape <see cref="ParameterType"/>
+        /// </summary>
+        ParameterType ExternalShape { get; }
+
+        /// <summary>
         /// Refreshes the defined <see cref="ParameterType"/>
         /// </summary>
         void RefreshParameterType();

--- a/DEHCATIA/Services/ParameterTypeService/ParameterTypeService.cs
+++ b/DEHCATIA/Services/ParameterTypeService/ParameterTypeService.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/Services/ParameterTypeService/ParameterTypeService.cs
+++ b/DEHCATIA/Services/ParameterTypeService/ParameterTypeService.cs
@@ -143,6 +143,11 @@ namespace DEHCATIA.Services.ParameterTypeService
         public const string ShapeAreaShortName = "area";
         
         /// <summary>
+        /// The Shape area <see cref="ParameterType"/> short name
+        /// </summary>
+        public const string ExternalShapeShortName = "external_shape";
+        
+        /// <summary>
         /// The NLog <see cref="Logger"/>
         /// </summary>
         private readonly Logger logger = LogManager.GetCurrentClassLogger();
@@ -348,6 +353,16 @@ namespace DEHCATIA.Services.ParameterTypeService
         public ParameterType ShapeSysMassMargin => this.shapeSysMassMargin ??= this.FetchParameterType(ShapeSysMassMarginShortName);
 
         /// <summary>
+        /// Backing field for <see cref="ExternalShape"/>
+        /// </summary>
+        private ParameterType externalShape;
+
+        /// <summary>
+        /// The Shape external shape <see cref="ParameterType"/>
+        /// </summary>
+        public ParameterType ExternalShape => this.externalShape ??= this.FetchParameterType(ExternalShapeShortName);
+
+        /// <summary>
         /// Initializes a new <see cref="ParameterTypeService"/>
         /// </summary>
         /// <param name="hubController">The <see cref="IHubController"/></param>
@@ -407,6 +422,7 @@ namespace DEHCATIA.Services.ParameterTypeService
             this.shapeSysMassMargin = null;
             this.shapeMassWithMargin = null;
             this.shapeDensity = null;
+            this.externalShape = null;
         }
 
         /// <summary>

--- a/DEHCATIA/ViewModels/CatiaTransferControlViewModel.cs
+++ b/DEHCATIA/ViewModels/CatiaTransferControlViewModel.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/ViewModels/Dialogs/HubMappingConfigurationDialogViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/HubMappingConfigurationDialogViewModel.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/ViewModels/Dialogs/HubMappingConfigurationDialogViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/HubMappingConfigurationDialogViewModel.cs
@@ -165,7 +165,6 @@ namespace DEHCATIA.ViewModels.Dialogs
                 }));
 
             this.WhenAnyValue(x => x.SelectedDstElement)
-                //.Subscribe(this.UpdateCatiaElement);
                 .Subscribe(x => this.SelectedMappedElement?.UpdateTheCatiaElement(x));
 
             this.WhenAnyValue(x => x.SelectedHubThing)
@@ -178,16 +177,6 @@ namespace DEHCATIA.ViewModels.Dialogs
 
             this.MappedElements.ItemChanged.Subscribe(x => this.CheckCanContinue());
         }
-
-        ///// <summary>
-        ///// Updates the <see cref="SelectedMappedElement"/> Catia Element
-        ///// </summary>
-        ///// <param name="element">The target <see cref="ElementRowViewModel"/></param>
-        //private void UpdateCatiaElement(ElementRowViewModel element)
-        //{
-        //    this.SelectedMappedElement?.UpdateTheCatiaElement(element);
-        //    this.VerifyValidityOfAllRow();
-        //}
 
         /// <summary>
         /// Verifies validity for all <see cref="MappedElements"/>

--- a/DEHCATIA/ViewModels/Dialogs/Interfaces/IHubMappingConfigurationDialogViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/Interfaces/IHubMappingConfigurationDialogViewModel.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/ViewModels/NetChangePreview/DstNetChangePreviewViewModel.cs
+++ b/DEHCATIA/ViewModels/NetChangePreview/DstNetChangePreviewViewModel.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/ViewModels/NetChangePreview/HubNetChangePreviewViewModel.cs
+++ b/DEHCATIA/ViewModels/NetChangePreview/HubNetChangePreviewViewModel.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/ViewModels/ProductTree/Parameters/DstParameterViewModel.cs
+++ b/DEHCATIA/ViewModels/ProductTree/Parameters/DstParameterViewModel.cs
@@ -85,7 +85,7 @@ namespace DEHCATIA.ViewModels.ProductTree.Parameters
             get => this.isQuantityKind;
             set => this.RaiseAndSetIfChanged(ref this.isQuantityKind, value);
         }
-        
+
         /// <summary>
         /// Gets or sets the Value
         /// </summary>

--- a/DEHCATIA/ViewModels/ProductTree/Parameters/ThreePointCoordinatesValueViewModel.cs
+++ b/DEHCATIA/ViewModels/ProductTree/Parameters/ThreePointCoordinatesValueViewModel.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/ViewModels/ProductTree/Rows/DefinitionRowViewModel.cs
+++ b/DEHCATIA/ViewModels/ProductTree/Rows/DefinitionRowViewModel.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/ViewModels/ProductTree/Rows/UsageRowViewModel.cs
+++ b/DEHCATIA/ViewModels/ProductTree/Rows/UsageRowViewModel.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/ViewModels/ProductTree/Shapes/PositionParameterValueViewModel.cs
+++ b/DEHCATIA/ViewModels/ProductTree/Shapes/PositionParameterValueViewModel.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/ViewModels/ProductTree/Shapes/PositionParameterValueViewModel.cs
+++ b/DEHCATIA/ViewModels/ProductTree/Shapes/PositionParameterValueViewModel.cs
@@ -24,6 +24,8 @@
 
 namespace DEHCATIA.ViewModels.ProductTree.Shapes
 {
+    using System.Collections.Generic;
+
     using DEHCATIA.ViewModels.ProductTree.Parameters;
 
     /// <summary>

--- a/DEHCATIA/ViewModels/Rows/MappedElementRowViewModel.cs
+++ b/DEHCATIA/ViewModels/Rows/MappedElementRowViewModel.cs
@@ -4,14 +4,14 @@
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 // 
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 // 
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 // 
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/ViewModels/Rows/MappedElementRowViewModel.cs
+++ b/DEHCATIA/ViewModels/Rows/MappedElementRowViewModel.cs
@@ -123,7 +123,6 @@ namespace DEHCATIA.ViewModels.Rows
 
             this.WhenAnyValue(x => x.ShouldCreateNewElement)
                 .Subscribe(_ => this.UpdateTheCatiaElement(this.CatiaElement ?? this.CatiaParent));
-
         }
 
         /// <summary>
@@ -160,7 +159,10 @@ namespace DEHCATIA.ViewModels.Rows
                 this.IsValid = null;
             }
 
-            CDPMessageBus.Current.SendMessage(new SelectEvent(this.HubElement, this.IsValid != true));
+            if (this.HubElement != null)
+            {
+                CDPMessageBus.Current.SendMessage(new SelectEvent(this.HubElement, this.IsValid != true));
+            }
         }
     }
 }

--- a/DEHCATIA/Views/DstNetChangePreview.xaml.cs
+++ b/DEHCATIA/Views/DstNetChangePreview.xaml.cs
@@ -4,14 +4,14 @@
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 //
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 //
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 //
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.

--- a/DEHCATIA/Views/Rows/MappingRow.xaml.cs
+++ b/DEHCATIA/Views/Rows/MappingRow.xaml.cs
@@ -4,14 +4,14 @@
 //
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
 //
-//    This file is part of DEHPEcosimPro
+//    This file is part of DEHCATIA
 //
-//    The DEHPEcosimPro is free software; you can redistribute it and/or
+//    The DEHCATIA is free software; you can redistribute it and/or
 //    modify it under the terms of the GNU Lesser General Public
 //    License as published by the Free Software Foundation; either
 //    version 3 of the License, or (at your option) any later version.
 //
-//    The DEHPEcosimPro is distributed in the hope that it will be useful,
+//    The DEHCATIA is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 //    Lesser General Public License for more details.


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEH-CATIA/pulls) open
- [x] I have verified that I am following the DEH-CATIA [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEH-CATIA/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
- [x] Implemented the rule that handles mapping from 10-25 to Catia
    - [x] Mapping of parameters
    - [x] Mapping of Position and Orientation
    - [x] Mapping of new Catia Element
- [x] Added a WIP of the CatiaShapeTemplateService
- [x] Added some unit test
<!-- Thanks for contributing to DEH-CATIA! -->