### PR TITLE
Imp/gh57 decoupling thing fix transfer; fixes #57

### DIFF
--- a/DEHCATIA.Tests/DEHCATIA.Tests.csproj
+++ b/DEHCATIA.Tests/DEHCATIA.Tests.csproj
@@ -89,6 +89,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="JetBrains.DotMemoryUnit" Version="3.1.20200127.214830" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/DEHCATIA.Tests/DstController/DstControllerTestFixture.cs
+++ b/DEHCATIA.Tests/DstController/DstControllerTestFixture.cs
@@ -221,7 +221,7 @@ namespace DEHCATIA.Tests.DstController
         [Test]
         public void VerifyTransferToHub()
         {
-            this.controller.ExternalIdentifierMap = new ExternalIdentifierMap();
+            this.controller.ExternalIdentifierMap = new ExternalIdentifierMap() {Correspondence = { new IdCorrespondence()}};
             
             this.navigationService.Setup(
                 x => x.ShowDxDialog<CreateLogEntryDialog, CreateLogEntryDialogViewModel>(
@@ -481,6 +481,21 @@ namespace DEHCATIA.Tests.DstController
             this.comService.Setup(x => x.AddOrUpdateElement(It.IsAny<MappedElementRowViewModel>())).Throws<InvalidOperationException>();
             this.controller.TransferMappedThingToCatia();
             this.comService.Verify(x => x.AddOrUpdateElement(It.IsAny<MappedElementRowViewModel>()), Times.Exactly(24));
+        }
+
+        [Test]
+        public void VerifyMappedThings()
+        {
+            this.elementRow.Children.Add(new UsageRowViewModel(this.product1.Object, "")
+                {
+                    ElementDefinition = this.element, ElementUsage = new ElementUsage() {ElementDefinition = this.element}
+                });
+
+            this.iteration.Element.Add(this.element);
+            this.hubController.Setup(x => x.OpenIteration).Returns(this.iteration);
+
+            this.elementRow.ElementDefinition = this.element;
+            Assert.DoesNotThrow(() => this.controller.RefreshMappedThings(new []{this.elementRow}));
         }
     }
 }

--- a/DEHCATIA.Tests/ViewModels/CatiaStatusBarControlViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/CatiaStatusBarControlViewModelTestFixture.cs
@@ -22,30 +22,27 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace DEHCATIA.ViewModels
+namespace DEHCATIA.Tests.ViewModels
 {
+    using DEHCATIA.ViewModels;
+
     using DEHPCommon.Services.NavigationService;
-    using DEHPCommon.UserInterfaces.ViewModels;
 
-    /// <summary>
-    /// The <see cref="CatiaStatusBarControlViewModel"/> is the main view  model of the status bar of this dst adapter
-    /// </summary>
-    public class CatiaStatusBarControlViewModel : StatusBarControlViewModel
+    using Moq;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CatiaStatusBarControlViewModelTestFixture
     {
-        /// <summary>
-        /// Initializes a new <see cref="T:DEHPCommon.UserInterfaces.ViewModels.StatusBarControlViewModel" />
-        /// </summary>
-        /// <param name="navigationService">The <see cref="INavigationService"/></param>
-        public CatiaStatusBarControlViewModel(INavigationService navigationService) : base(navigationService)
+        [Test]
+        public void VerifyExecuteUserSettingsCommand()
         {
-        }
-
-        /// <summary>
-        /// Executes the <see cref="P:DEHPCommon.UserInterfaces.ViewModels.StatusBarControlViewModel.UserSettingCommand" />
-        /// </summary>
-        protected override void ExecuteUserSettingCommand()
-        {
-            this.Append("User settings opened");
+            var viewModel = new CatiaStatusBarControlViewModel(new Mock<INavigationService>().Object);
+            Assert.IsTrue(viewModel.UserSettingCommand.CanExecute(null));
+            Assert.DoesNotThrow(() => viewModel.UserSettingCommand.Execute(null));
+            
+            Assert.IsFalse(string.IsNullOrWhiteSpace(viewModel.Message));
         }
     }
 }

--- a/DEHCATIA.Tests/ViewModels/CatiaTransferControlViewModelTestFixture.cs
+++ b/DEHCATIA.Tests/ViewModels/CatiaTransferControlViewModelTestFixture.cs
@@ -25,7 +25,6 @@
 namespace DEHCATIA.Tests.ViewModels
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
 
     using CDP4Common.EngineeringModelData;
@@ -45,8 +44,6 @@ namespace DEHCATIA.Tests.ViewModels
     using Moq;
 
     using NUnit.Framework;
-
-    using ProductStructureTypeLib;
 
     using ReactiveUI;
 

--- a/DEHCATIA/App.xaml.cs
+++ b/DEHCATIA/App.xaml.cs
@@ -161,6 +161,7 @@ namespace DEHCATIA
             containerBuilder.RegisterType<HubNetChangePreviewViewModel>().As<IHubNetChangePreviewViewModel>().SingleInstance();
             containerBuilder.RegisterType<DstNetChangePreviewViewModel>().As<IDstNetChangePreviewViewModel>().SingleInstance();
             containerBuilder.RegisterType<DstLoginViewModel>().As<IDstLoginViewModel>();
+            containerBuilder.RegisterType<CatiaStatusBarControlViewModel>().As<IStatusBarControlViewModel>().SingleInstance();
         }
     }   
 }

--- a/DEHCATIA/DEHCATIA.csproj
+++ b/DEHCATIA/DEHCATIA.csproj
@@ -96,7 +96,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-    <PackageReference Include="DEHPCommon" Version="1.0.219" />
+    <PackageReference Include="DEHPCommon" Version="1.0.224" />
     <PackageReference Include="NLog" Version="4.6.8" />
     <PackageReference Include="NLog.Schema" Version="4.6.8" />
     <PackageReference Include="reactiveui" Version="6.5.0" />

--- a/DEHCATIA/DstController/DstController.cs
+++ b/DEHCATIA/DstController/DstController.cs
@@ -219,6 +219,7 @@ namespace DEHCATIA.DstController
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(x =>
                 {
+                    this.RefreshMappedThings();
                     this.Map(this.ReadyToMapTopElement);
                     this.ReadyToMapTopElement = null;
                 });
@@ -246,6 +247,36 @@ namespace DEHCATIA.DstController
             if (shouldResetTheTrees)
             {
                 CDPMessageBus.Current.SendMessage(new UpdateObjectBrowserTreeEvent(true));
+            }
+        }
+
+        /// <summary>
+        /// Refreshes mapped <see cref="ElementDefinition"/> and <see cref="ElementUsage"/>
+        /// </summary>
+        /// <param name="elements">The collection of <see cref="ElementRowViewModel"/></param>
+        public void RefreshMappedThings(IEnumerable<ElementRowViewModel> elements = null)
+        {
+            elements ??= new []{ this.ReadyToMapTopElement };
+
+            foreach (var element in elements)
+            {
+                if (element?.ElementDefinition is { })
+                {
+                    element.ElementDefinition = this.hubController.OpenIteration.Element.FirstOrDefault(x => x.Iid == element.ElementDefinition.Iid)?.Clone(true);
+                }
+
+                if (element is UsageRowViewModel usageRow && usageRow.ElementUsage is { } && element.ElementDefinition is { } elementDefinition)
+                {
+                    usageRow.ElementUsage =
+                        this.hubController.OpenIteration.Element.SelectMany(d => d.ContainedElement)
+                            .Where(u => u.ElementDefinition.Iid == elementDefinition.Iid)
+                            .FirstOrDefault(x => x.Iid == usageRow.ElementUsage.Iid)?.Clone(true);
+                }
+
+                if (element?.Children.Any() == true)
+                {
+                    this.RefreshMappedThings(element.Children);
+                }
             }
         }
 
@@ -463,9 +494,9 @@ namespace DEHCATIA.DstController
                 }
             }
         }
-        
+
         /// <summary>
-        /// Transfers the <see cref="DstMapResult"/> to the Hub
+        /// Transfers the <see cref="SelectedThingsToTransfer"/> to the Hub
         /// </summary>
         /// <returns>A <see cref="Task"/></returns>
         public async Task TransferMappedThingsToHub()
@@ -755,6 +786,10 @@ namespace DEHCATIA.DstController
             {
                 this.ExternalIdentifierMap = this.ExternalIdentifierMap.Clone(true);
                 this.ExternalIdentifierMap.Iid = Guid.NewGuid();
+            }
+
+            if (iterationClone.ExternalIdentifierMap.All(x => x.Iid != this.ExternalIdentifierMap.Iid))
+            {
                 iterationClone.ExternalIdentifierMap.Add(this.ExternalIdentifierMap);
             }
 

--- a/DEHCATIA/DstController/IDstController.cs
+++ b/DEHCATIA/DstController/IDstController.cs
@@ -101,6 +101,12 @@ namespace DEHCATIA.DstController
         void ResetMappedElement(bool shouldResetTheTrees = false);
 
         /// <summary>
+        /// Refreshes mapped <see cref="ElementDefinition"/> and <see cref="ElementUsage"/>
+        /// </summary>
+        /// <param name="elements">The collection of <see cref="ElementRowViewModel"/></param>
+        void RefreshMappedThings(IEnumerable<ElementRowViewModel> elements = null);
+
+        /// <summary>
         /// Loads the mapping configuration and generates the map result respectively
         /// </summary>
         void LoadMapping();
@@ -139,7 +145,7 @@ namespace DEHCATIA.DstController
         void TransferMappedThingToCatia();
 
         /// <summary>
-        /// Transfers the <see cref="DstController.DstMapResult"/> to the Hub
+        /// Transfers the <see cref="DstController.SelectedThingsToTransfer"/> to the Hub
         /// </summary>
         /// <returns>A <see cref="Task"/></returns>
         Task TransferMappedThingsToHub();

--- a/DEHCATIA/MappingRules/CatiaProductToElementRule.cs
+++ b/DEHCATIA/MappingRules/CatiaProductToElementRule.cs
@@ -134,6 +134,7 @@ namespace DEHCATIA.MappingRules
                     this.MapElementUsage(usageRow);
                     this.MapParameters(usageRow);
                     this.dstController.SaveElementMapping(usageRow);
+                    this.ruleOutput.Add((usageRow.Parent, usageRow.ElementDefinition));
                     this.ruleOutput.Add((usageRow.Parent, usageRow.ElementUsage));
                 }
                 else

--- a/DEHCATIA/MappingRules/CatiaProductToElementRule.cs
+++ b/DEHCATIA/MappingRules/CatiaProductToElementRule.cs
@@ -98,6 +98,8 @@ namespace DEHCATIA.MappingRules
         {
             try
             {
+                this.ruleOutput.Clear();
+
                 this.owner = this.hubController.CurrentDomainOfExpertise;
                 this.dstController = AppContainer.Container.Resolve<IDstController>();
 
@@ -132,7 +134,6 @@ namespace DEHCATIA.MappingRules
                     this.MapElementUsage(usageRow);
                     this.MapParameters(usageRow);
                     this.dstController.SaveElementMapping(usageRow);
-                    this.ruleOutput.Add((usageRow.Parent, usageRow.ElementDefinition));
                     this.ruleOutput.Add((usageRow.Parent, usageRow.ElementUsage));
                 }
                 else

--- a/DEHCATIA/Services/ComConnector/CatiaComService.cs
+++ b/DEHCATIA/Services/ComConnector/CatiaComService.cs
@@ -824,7 +824,7 @@ namespace DEHCATIA.Services.ComConnector
     /// </summary>
     /// <param name="parameters">The <see cref="Parameters"/></param>
     /// <param name="parameter">The <see cref="IDstParameterViewModel"/></param>
-    private void CreateParameter(Parameters parameters, IDstParameterViewModel parameter)
+    public void CreateParameter(Parameters parameters, IDstParameterViewModel parameter)
     {
         var parameterShortName = parameter.Name;
 

--- a/DEHCATIA/ViewModels/CatiaStatusBarControlViewModel.cs
+++ b/DEHCATIA/ViewModels/CatiaStatusBarControlViewModel.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="DefinitionRowViewModel.cs" company="RHEA System S.A.">
+// <copyright file="CatiaStatusBarControlViewModel.cs" company="RHEA System S.A.">
 //    Copyright (c) 2020-2021 RHEA System S.A.
 // 
 //    Author: Sam Gerené, Alex Vorobiev, Alexander van Delft, Nathanael Smiechowski.
@@ -22,32 +22,30 @@
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 
-namespace DEHCATIA.ViewModels.ProductTree.Rows
+namespace DEHCATIA.ViewModels
 {
-    using CDP4Common.EngineeringModelData;
-
-    using DEHCATIA.Enumerations;
-
-    using ProductStructureTypeLib;
+    using DEHPCommon.Services.NavigationService;
+    using DEHPCommon.UserInterfaces.ViewModels;
 
     /// <summary>
-    /// The <see cref="DefinitionRowViewModel"/> is a specific <see cref="ElementRowViewModel"/>
-    /// mappable to a <see cref="ElementDefinition"/> and representing a catia element of type <see cref="ElementType.CatDefinition"/>
+    /// The <see cref="CatiaStatusBarControlViewModel"/> is the main view  model of the status bar of this dst adapter
     /// </summary>
-    public class DefinitionRowViewModel : ElementRowViewModel
+    public class CatiaStatusBarControlViewModel : StatusBarControlViewModel
     {
         /// <summary>
-        /// Gets or sets the type.
+        /// Initializes a new <see cref="T:DEHPCommon.UserInterfaces.ViewModels.StatusBarControlViewModel" />
         /// </summary>
-        public override ElementType ElementType => ElementType.CatDefinition;
+        /// <param name="navigationService">The <see cref="INavigationService"/></param>
+        public CatiaStatusBarControlViewModel(INavigationService navigationService) : base(navigationService)
+        {
+        }
 
         /// <summary>
-        /// Initializes a new <see cref="DefinitionRowViewModel"/>
+        /// Executes the <see cref="P:DEHPCommon.UserInterfaces.ViewModels.StatusBarControlViewModel.UserSettingCommand" />
         /// </summary>
-        /// <param name="product">The <see cref="Product"/> this view model represents</param>
-        /// <param name="fileName">The file name of the <paramref name="product"/></param>
-        public DefinitionRowViewModel(Product product, string fileName) : base(product, fileName)
+        protected override void ExecuteUserSettingCommand()
         {
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/DEHCATIA/ViewModels/CatiaTransferControlViewModel.cs
+++ b/DEHCATIA/ViewModels/CatiaTransferControlViewModel.cs
@@ -33,7 +33,6 @@ namespace DEHCATIA.ViewModels
     using CDP4Common.Extensions;
 
     using CDP4Dal;
-    using CDP4Dal.Events;
 
     using DEHCATIA.DstController;
     using DEHCATIA.Events;

--- a/DEHCATIA/ViewModels/Dialogs/DstMappingConfigurationDialogViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/DstMappingConfigurationDialogViewModel.cs
@@ -28,24 +28,16 @@ namespace DEHCATIA.ViewModels.Dialogs
     using System.Collections.Generic;
     using System.Linq;
     using System.Reactive.Linq;
-    using System.Threading.Tasks;
     using System.Windows.Input;
 
-    using CDP4Common.CommonData;
     using CDP4Common.EngineeringModelData;
-    using CDP4Common.SiteDirectoryData;
-
-    using CDP4Dal;
 
     using DEHCATIA.DstController;
     using DEHCATIA.ViewModels.Dialogs.Interfaces;
     using DEHCATIA.ViewModels.ProductTree.Rows;
 
-    using DEHPCommon.Events;
     using DEHPCommon.HubController.Interfaces;
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
-
-    using DevExpress.Xpo.DB.Helpers;
 
     using ReactiveUI;
 

--- a/DEHCATIA/ViewModels/Dialogs/DstMappingConfigurationDialogViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/DstMappingConfigurationDialogViewModel.cs
@@ -157,33 +157,6 @@ namespace DEHCATIA.ViewModels.Dialogs
                     });
                 });
         }
-
-        /// <summary>
-        /// Refreshes mapped <see cref="ElementDefinition"/> and <see cref="ElementUsage"/>
-        /// </summary>
-        /// <param name="elements">The collection of <see cref="ElementRowViewModel"/></param>
-        private void RefreshMappedThings(IEnumerable<ElementRowViewModel> elements = null)
-        {
-            elements ??= this.Elements;
-
-            foreach (var element in elements)
-            {
-                if (element.ElementDefinition is {})
-                {
-                    element.ElementDefinition = this.AvailableElementDefinitions.FirstOrDefault(x => x.Iid == element.ElementDefinition.Iid);
-                }
-
-                if (element is UsageRowViewModel usageRow && usageRow.ElementUsage is {} && element.ElementDefinition is {} elementDefinition)
-                {
-                    usageRow.ElementUsage = 
-                        this.AvailableElementDefinitions.SelectMany(d => d.ContainedElement)
-                            .Where(u => u.ElementDefinition.Iid == elementDefinition.Iid)
-                            .FirstOrDefault(x => x.Iid == usageRow.ElementUsage.Iid);
-                }
-
-                this.RefreshMappedThings(element.Children);
-            }
-        }
         
         /// <summary>
         /// Initializes this view model <see cref="ICommand"/> and <see cref="Observable"/>

--- a/DEHCATIA/ViewModels/Dialogs/DstMappingConfigurationDialogViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/DstMappingConfigurationDialogViewModel.cs
@@ -152,7 +152,7 @@ namespace DEHCATIA.ViewModels.Dialogs
                     {
                         this.InitializesCommandsAndObservableSubscriptions();
                         this.UpdateProperties();
-                        this.RefreshMappedThings();
+                        this.DstController.RefreshMappedThings();
                         this.CheckCanExecute();
                     });
                 });

--- a/DEHCATIA/ViewModels/Dialogs/Interfaces/IDstLoginViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/Interfaces/IDstLoginViewModel.cs
@@ -24,12 +24,6 @@
 
 namespace DEHCATIA.ViewModels.Dialogs.Interfaces
 {
-    using System.Reactive;
-
-    using DEHPCommon.UserInterfaces.Behaviors;
-
-    using ReactiveUI;
-
     /// <summary>
     /// Interface definiton for <see cref="DstLoginViewModel"/>
     /// </summary>

--- a/DEHCATIA/ViewModels/Dialogs/Interfaces/IDstMappingConfigurationDialogViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/Interfaces/IDstMappingConfigurationDialogViewModel.cs
@@ -24,11 +24,7 @@
 
 namespace DEHCATIA.ViewModels.Dialogs.Interfaces
 {
-    using System.Reactive.Linq;
-    using System.Windows.Input;
-
     using CDP4Common.EngineeringModelData;
-    using CDP4Common.SiteDirectoryData;
 
     using DEHCATIA.ViewModels.ProductTree.Rows;
 

--- a/DEHCATIA/ViewModels/Dialogs/MappingConfigurationDialogViewModel.cs
+++ b/DEHCATIA/ViewModels/Dialogs/MappingConfigurationDialogViewModel.cs
@@ -25,7 +25,6 @@
 namespace DEHCATIA.ViewModels.Dialogs
 {
     using System;
-    using System.Windows;
     using System.Windows.Input;
 
     using DEHCATIA.DstController;

--- a/DEHCATIA/ViewModels/DstDataSourceViewModel.cs
+++ b/DEHCATIA/ViewModels/DstDataSourceViewModel.cs
@@ -26,10 +26,7 @@ namespace DEHCATIA.ViewModels
 {
     using System;
     using System.Diagnostics;
-    using System.Reactive;
     using System.Reactive.Linq;
-    using System.Threading;
-    using System.Threading.Tasks;
 
     using Autofac;
 
@@ -47,6 +44,8 @@ namespace DEHCATIA.ViewModels
     using DEHPCommon.Services.NavigationService;
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
 
+    using NLog;
+
     using ReactiveUI;
 
     /// <summary>
@@ -54,6 +53,11 @@ namespace DEHCATIA.ViewModels
     /// </summary>
     public sealed class DstDataSourceViewModel : DataSourceViewModel, IDstDataSourceViewModel
     {
+        /// <summary>
+        /// The <see cref="NLog"/> logger
+        /// </summary>
+        private readonly Logger logger = LogManager.GetCurrentClassLogger();
+
         /// <summary>
         /// The <see cref="IDstController"/> instance.
         /// </summary>
@@ -96,7 +100,7 @@ namespace DEHCATIA.ViewModels
         /// <summary>
         /// Gets or sets the command that refreshes the connection and the product tree
         /// </summary>
-        public ReactiveCommand<Unit> RefreshCommand { get; set; }
+        public ReactiveCommand<object> RefreshCommand { get; set; }
 
         /// <summary>
         /// Initializes a new instance of <see cref="DstDataSourceViewModel"/>.
@@ -152,24 +156,35 @@ namespace DEHCATIA.ViewModels
                         x.Value is null  && c.Value && i.Value != null)
                 .ObserveOn(RxApp.MainThreadScheduler);
 
-            this.RefreshCommand = ReactiveCommand.CreateAsyncTask(canRefresh, _ => this.RefreshCommandExecute());
+            this.RefreshCommand = ReactiveCommand.Create(canRefresh);
+            this.RefreshCommand.Subscribe(_ => this.RefreshCommandExecute());
         }
 
         /// <summary>
         /// Executes the <see cref="RefreshCommand"/>
         /// </summary>
         /// <returns></returns>
-        private async Task RefreshCommandExecute()
+        private void RefreshCommandExecute()
         {
-            this.statusBar.Append($"Refreshing the Catia Product tree in progress");
+            var isCompleted = false;
             var timer = new Stopwatch();
-            timer.Start();
 
-            await Task.Run(() => this.dstController.Refresh()).ContinueWith(_ =>
+            try
+            {
+                this.statusBar.Append($"Refreshing the Catia Product tree in progress");
+                timer.Start();
+                this.dstController.Refresh();
+                isCompleted = true;
+            }
+            catch (Exception exception)
+            {
+                this.logger.Error(exception);
+            }
+            finally
             {
                 timer.Stop();
-                this.statusBar.Append($"Refresh {(_.IsCompleted ? "has complete in" : "has failed after")} {timer.ElapsedMilliseconds} ms");
-            });
+                this.statusBar.Append($"Refresh {(isCompleted ? "has complete in" : "has failed after")} {timer.ElapsedMilliseconds} ms");
+            }
         }
 
         /// <summary>

--- a/DEHCATIA/ViewModels/DstDataSourceViewModel.cs
+++ b/DEHCATIA/ViewModels/DstDataSourceViewModel.cs
@@ -163,7 +163,6 @@ namespace DEHCATIA.ViewModels
         /// <summary>
         /// Executes the <see cref="RefreshCommand"/>
         /// </summary>
-        /// <returns></returns>
         private void RefreshCommandExecute()
         {
             var isCompleted = false;

--- a/DEHCATIA/ViewModels/Interfaces/IMainWindowViewModel.cs
+++ b/DEHCATIA/ViewModels/Interfaces/IMainWindowViewModel.cs
@@ -27,7 +27,6 @@ namespace DEHCATIA.ViewModels.Interfaces
     using System.Windows.Input;
 
     using DEHPCommon.UserInterfaces.ViewModels.Interfaces;
-    using DEHPCommon.UserInterfaces.ViewModels.NetChangePreview.Interfaces;
 
     using ReactiveUI;
 

--- a/DEHCATIA/ViewModels/MainWindowViewModel.cs
+++ b/DEHCATIA/ViewModels/MainWindowViewModel.cs
@@ -141,7 +141,7 @@ namespace DEHCATIA.ViewModels
             this.HubNetChangePreviewViewModel = hubNetChangePreviewViewModel;
             this.DstNetChangePreviewViewModel = dstNetChangePreviewViewModel;
 
-            var areTemplateReadyMessage = templateService.AreAllTemplatesAvailable() 
+            var areTemplateReadyMessage = templateService.AreAllTemplatesAvailable()
                 ? $"All templates are ready."
                 : $"Some template files are missing.";
 

--- a/DEHCATIA/ViewModels/MainWindowViewModel.cs
+++ b/DEHCATIA/ViewModels/MainWindowViewModel.cs
@@ -27,8 +27,6 @@ namespace DEHCATIA.ViewModels
     using System;
     using System.Windows.Input;
 
-    using Autofac;
-
     using DEHCATIA.DstController;
     using DEHCATIA.Services.CatiaTemplateService;
 
@@ -37,12 +35,8 @@ namespace DEHCATIA.ViewModels
 
     using DEHCATIA.ViewModels.Interfaces;
 
-    using DEHPCommon;
     using DEHPCommon.Services.NavigationService;
-    using DEHPCommon.UserInterfaces.ViewModels.NetChangePreview.Interfaces;
     using DEHPCommon.UserInterfaces.Views.ExchangeHistory;
-
-    using DevExpress.Xpo.Exceptions;
 
     using ReactiveUI;
 

--- a/DEHCATIA/ViewModels/NetChangePreview/DstNetChangePreviewViewModel.cs
+++ b/DEHCATIA/ViewModels/NetChangePreview/DstNetChangePreviewViewModel.cs
@@ -28,7 +28,8 @@ namespace DEHCATIA.ViewModels.NetChangePreview
     using System.Collections.Generic;
     using System.Linq;
     using System.Reactive.Linq;
-    
+    using System.Windows.Input;
+
     using CDP4Dal;
 
     using DEHCATIA.Events;
@@ -85,6 +86,26 @@ namespace DEHCATIA.ViewModels.NetChangePreview
             CDPMessageBus.Current.Listen<UpdateDstPreviewBasedOnSelectionEvent>()
                 .ObserveOn(RxApp.MainThreadScheduler)
                 .Subscribe(x => this.UpdateTreeBasedOnSelectionHandler(x.Selection.ToList()));
+
+            this.InitializeCommandsAndObservables();
+        }
+
+        /// <summary>
+        /// Initializes the <see cref="ICommand"/> of this view model and the observable
+        /// </summary>
+        public override void InitializeCommandsAndObservables()
+        {
+            this.WhenAnyValue(x => x.DstController.ProductTree)
+                .ObserveOn(RxApp.MainThreadScheduler)
+                .Subscribe(x =>
+                {
+                    this.RootElements.Clear();
+
+                    if (x is { })
+                    {
+                        this.RootElements.Add(x);
+                    }
+                });
         }
 
         /// <summary>
@@ -173,24 +194,6 @@ namespace DEHCATIA.ViewModels.NetChangePreview
         private void UpdateElementRow(MappedElementRowViewModel mappedElement)
         {
             CDPMessageBus.Current.SendMessage(new DstHighlightEvent(mappedElement.CatiaElement.Name));
-        }
-
-        /// <summary>
-        /// Updates the <see cref="ProductTree"/> after a CATIA connection update.
-        /// </summary>
-        protected override void UpdateProductTree()
-        {
-            this.RootElement = null;
-            this.IsBusy = true;
-
-            this.WhenAny(x => x.DstController.ProductTree,
-                    x => x.Value)
-                .Where(x => x != null)
-                .Subscribe(p =>
-                {
-                    this.RootElement = p;
-                    this.IsBusy = false;
-                });
         }
 
         /// <summary>

--- a/DEHCATIA/ViewModels/NetChangePreview/DstNetChangePreviewViewModel.cs
+++ b/DEHCATIA/ViewModels/NetChangePreview/DstNetChangePreviewViewModel.cs
@@ -172,7 +172,7 @@ namespace DEHCATIA.ViewModels.NetChangePreview
         /// </summary>
         private void Reload()
         {
-            CDPMessageBus.Current.SendMessage(new DstHighlightEvent(this.RootElement.Name, false));
+            CDPMessageBus.Current.SendMessage(new DstHighlightEvent(this.RootElement?.Name, false));
             this.RootElements.Clear();
         }
         

--- a/DEHCATIA/ViewModels/NetChangePreview/DstNetChangePreviewViewModel.cs
+++ b/DEHCATIA/ViewModels/NetChangePreview/DstNetChangePreviewViewModel.cs
@@ -193,7 +193,7 @@ namespace DEHCATIA.ViewModels.NetChangePreview
         /// <param name="mappedElement">The source <see cref="MappedElementRowViewModel"/></param>
         private void UpdateElementRow(MappedElementRowViewModel mappedElement)
         {
-            CDPMessageBus.Current.SendMessage(new DstHighlightEvent(mappedElement.CatiaElement.Name));
+            CDPMessageBus.Current.SendMessage(new DstHighlightEvent(mappedElement.CatiaElement?.Name));
         }
 
         /// <summary>

--- a/DEHCATIA/ViewModels/ProductTree/Parameters/DstParameterViewModel.cs
+++ b/DEHCATIA/ViewModels/ProductTree/Parameters/DstParameterViewModel.cs
@@ -132,7 +132,7 @@ namespace DEHCATIA.ViewModels.ProductTree.Parameters
         {
             this.Parameter = parameter;
             this.IsQuantityKind = parameter is RealParam;
-            this.ModelCode = parameter?.get_Name().Replace("\\", ".");
+            this.ModelCode = parameter?.get_Name()?.Replace("\\", ".");
             this.Comment = parameter?.get_Comment();
             this.ValueFromCatia = parameter?.ValueAsString();
         }

--- a/DEHCATIA/ViewModels/ProductTree/Parameters/ShapeKindParameterViewModel.cs
+++ b/DEHCATIA/ViewModels/ProductTree/Parameters/ShapeKindParameterViewModel.cs
@@ -27,8 +27,6 @@ namespace DEHCATIA.ViewModels.ProductTree.Parameters
     using DEHCATIA.Enumerations;
     using DEHCATIA.Extensions;
 
-    using KnowledgewareTypeLib;
-
     /// <summary>
     /// The <see cref="ShapeKindParameterViewModel"/> represents a Parameter in a element of the Catia Product tree that holds a <see cref="ShapeKind"/>
     /// </summary>

--- a/DEHCATIA/ViewModels/ProductTree/Rows/ElementRowViewModel.cs
+++ b/DEHCATIA/ViewModels/ProductTree/Rows/ElementRowViewModel.cs
@@ -37,8 +37,6 @@ namespace DEHCATIA.ViewModels.ProductTree.Rows
     using DEHCATIA.ViewModels.ProductTree.Parameters;
     using DEHCATIA.ViewModels.ProductTree.Shapes;
 
-    using DEHPCommon.Events;
-
     using ProductStructureTypeLib;
 
     using ReactiveUI;

--- a/DEHCATIA/ViewModels/ProductTree/Shapes/CatiaShapeViewModel.cs
+++ b/DEHCATIA/ViewModels/ProductTree/Shapes/CatiaShapeViewModel.cs
@@ -28,7 +28,6 @@ namespace DEHCATIA.ViewModels.ProductTree.Shapes
     using System.Linq;
     using System.Reflection;
 
-    using DEHCATIA.Enumerations;
     using DEHCATIA.ViewModels.ProductTree.Parameters;
 
     using ReactiveUI;

--- a/DEHCATIA/ViewModels/ProductTree/Shapes/PositionParameterValueViewModel.cs
+++ b/DEHCATIA/ViewModels/ProductTree/Shapes/PositionParameterValueViewModel.cs
@@ -24,8 +24,6 @@
 
 namespace DEHCATIA.ViewModels.ProductTree.Shapes
 {
-    using System.Collections.Generic;
-
     using DEHCATIA.ViewModels.ProductTree.Parameters;
 
     /// <summary>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/DEH-CATIA/pulls) open
- [x] I have verified that I am following the DEH-CATIA [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/DEH-CATIA/master/.github/CONTRIBUTING.md)
- [x] I have provided test coverage for my change (where applicable)

### Description
continuation of [#58](https://github.com/RHEAGROUP/DEH-Common/pull/58)
Fixes [#57](https://github.com/RHEAGROUP/DEH-Common/issue/57)
<!-- A description of the changes proposed in the pull-request -->
 - [x] Bumped DEHCommon version with latest  
 - [x] Fixed transfer button gets disabled
 - [x] Fixed the externalIdentifier Container missing from the operation
 - [x] Fixed the mapped things dead reference after session.refresh or reload
 - [x] Fixed unselectable/highlight of selected things to transfer
 - [x] Fixed Has contained things
 - [x] Element usages disapearing => not observed anymore was certainly a side effect of one of the issues above
<!-- Thanks for contributing to DEH-CATIA! -->